### PR TITLE
SpreadsheetCellReference column/row

### DIFF
--- a/src/spreadsheet/SpreadsheetCell.test.js
+++ b/src/spreadsheet/SpreadsheetCell.test.js
@@ -6,7 +6,7 @@ import TextStyle from "../text/TextStyle";
 import Text from "../text/Text";
 
 function reference() {
-    return new SpreadsheetCellReference("A99");
+    return SpreadsheetCellReference.parse("A99");
 }
 
 function formula() {

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -1,35 +1,80 @@
 /**
  * Holds a cell reference. Note the reference is not validated in anyway.
  */
+import SpreadsheetColumnReference from "./SpreadsheetColumnReference";
+import SpreadsheetRowReference from "./SpreadsheetRowReference";
+
 export default class SpreadsheetCellReference {
 
-    static fromJson(reference) {
-        return SpreadsheetCellReference.parse(reference);
+    static fromJson(json) {
+        return SpreadsheetCellReference.parse(json);
     }
 
-    static parse(reference) {
-        return new SpreadsheetCellReference(reference);
-    }
-
-    constructor(reference) {
-        if (!reference) {
-            throw new Error("Missing reference");
+    static parse(text) {
+        if (!text) {
+            throw new Error("Missing text");
         }
-        if (typeof reference !== "string") {
-            throw new Error("Expected string got " + reference);
+        if (typeof text !== "string") {
+            throw new Error("Expected string got " + text);
         }
-        this.referenceValue = reference;
+
+        for (var i = 1; i < text.length; i++) {
+            switch (text.charAt(i)) {
+                case '$':
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    return new SpreadsheetCellReference(
+                        SpreadsheetColumnReference.parse(text.substring(0, i)),
+                        SpreadsheetRowReference.parse(text.substring(i))
+                    );
+                default:
+                    continue;
+            }
+        }
+
+        throw new Error("Missing row got " + text);
     }
 
-    reference() {
-        return this.referenceValue;
+    constructor(column, row) {
+        if (!column) {
+            throw new Error("Missing column");
+        }
+        if (!(column instanceof SpreadsheetColumnReference)) {
+            throw new Error("Expected SpreadsheetColumnReference column got " + column);
+        }
+
+        if (!row) {
+            throw new Error("Missing row");
+        }
+        if (!(row instanceof SpreadsheetRowReference)) {
+            throw new Error("Expected SpreadsheetRowReference row got " + row);
+        }
+
+        this.columnValue = column;
+        this.rowValue = row;
+    }
+
+    column() {
+        return this.columnValue;
+    }
+
+    row() {
+        return this.rowValue;
     }
 
     toJson() {
-        return this.reference();
+        return this.toString();
     }
 
     toString() {
-        return this.reference();
+        return this.column().toString() + this.row();
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetCellReference.test.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.test.js
@@ -1,39 +1,86 @@
 import SpreadsheetCellReference from "./SpreadsheetCellReference";
+import SpreadsheetColumnReference from "./SpreadsheetColumnReference";
+import SpreadsheetRowReference from "./SpreadsheetRowReference";
 
-const reference = "A1";
+function column() {
+    return SpreadsheetColumnReference.parse("A");
+};
 
-test("create without reference fails", () => {
-    expect(() => new SpreadsheetCellReference(null)).toThrow("Missing reference");
+function row() {
+    return SpreadsheetRowReference.parse("1");
+};
+
+test("create without column fails", () => {
+    expect(() => new SpreadsheetCellReference(null)).toThrow("Missing column");
 });
 
-test("create with non string fails", () => {
-    expect(() => new SpreadsheetCellReference(1.5)).toThrow("Expected string got 1.5");
+test("create with non SpreadsheetColumnReference fails", () => {
+    expect(() => new SpreadsheetCellReference(1.5)).toThrow("Expected SpreadsheetColumnReference column got 1.5");
 });
 
-test("create", () => {
-    const spreadsheetCellReference = new SpreadsheetCellReference(reference);
-    expect(spreadsheetCellReference.reference()).toBe(reference);
+test("create without row fails", () => {
+    expect(() => new SpreadsheetCellReference(column())).toThrow("Missing row");
+});
+
+test("create with non SpreadsheetRowReference fails", () => {
+    expect(() => new SpreadsheetCellReference(column(), 1.5)).toThrow("Expected SpreadsheetRowReference row got 1.5");
+});
+
+test("create A1", () => {
+    const c = column();
+    const r = row();
+    const cell = new SpreadsheetCellReference(c, r);
+
+    check(cell,
+        c,
+        r,
+        "A1");
+});
+
+test("create BC987", () => {
+    const c = SpreadsheetColumnReference.parse("$BC");
+    const r = SpreadsheetRowReference.parse("$987");
+    const cell = new SpreadsheetCellReference(c, r);
+
+    check(cell,
+        c,
+        r,
+        "$BC$987");
 });
 
 test("fromJson null fails", () => {
-    expect(() => SpreadsheetCellReference.fromJson(null)).toThrow("Missing reference");
+    expect(() => SpreadsheetCellReference.fromJson(null)).toThrow("Missing text");
 });
 
-test("json", () => {
-    const spreadsheetCellReference = new SpreadsheetCellReference(reference);
+test("fromJson A1", () => {
+    check(SpreadsheetCellReference.fromJson("A1"),
+        column(),
+        row(),
+        "A1");
+});
 
-    check(spreadsheetCellReference, reference);
+test("fromJson $A$1", () => {
+    check(SpreadsheetCellReference.fromJson("$A$1"),
+        SpreadsheetColumnReference.parse("$A"),
+        SpreadsheetRowReference.parse("$1"),
+        "$A$1");
 });
 
 // helpers..............................................................................................................
 
-function check(spreadsheetCellReference, reference) {
-    expect(spreadsheetCellReference.reference()).toStrictEqual(reference);
-    expect(spreadsheetCellReference.reference()).toBeString();
+function check(cell,
+               column,
+               row) {
+    expect(cell.column()).toStrictEqual(column);
+    expect(cell.column()).toBeInstanceOf(SpreadsheetColumnReference);
 
-    expect(spreadsheetCellReference.toJson()).toStrictEqual(reference);
-    expect(spreadsheetCellReference.toString()).toBe(reference);
+    expect(cell.row()).toStrictEqual(row);
+    expect(cell.row()).toBeInstanceOf(SpreadsheetRowReference);
 
-    expect(SpreadsheetCellReference.parse(spreadsheetCellReference.toJson())).toStrictEqual(spreadsheetCellReference);
-    expect(SpreadsheetCellReference.fromJson(spreadsheetCellReference.toJson())).toStrictEqual(spreadsheetCellReference);
+    const json = "" + column + row;
+    expect(cell.toJson()).toStrictEqual(json);
+    expect(cell.toString()).toBe(json);
+
+    expect(SpreadsheetCellReference.parse(json)).toStrictEqual(cell);
+    expect(SpreadsheetCellReference.fromJson(json)).toStrictEqual(cell);
 }

--- a/src/spreadsheet/reference/SpreadsheetRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRange.js
@@ -23,7 +23,10 @@ export default class SpreadsheetRange extends SpreadsheetRectangle{
             throw new Error("Expected 2 tokens got " + text);
         }
 
-        return new SpreadsheetRange(new SpreadsheetCellReference(tokens[0]), new SpreadsheetCellReference(tokens[1]));
+        return new SpreadsheetRange(
+            SpreadsheetCellReference.fromJson(tokens[0]),
+            SpreadsheetCellReference.fromJson(tokens[1])
+        );
     }
 
     constructor(begin, end) {

--- a/src/spreadsheet/reference/SpreadsheetRange.test.js
+++ b/src/spreadsheet/reference/SpreadsheetRange.test.js
@@ -2,11 +2,11 @@ import SpreadsheetRange from "./SpreadsheetRange";
 import SpreadsheetCellReference from "./SpreadsheetCellReference";
 
 function begin() {
-    return new SpreadsheetCellReference("A1");
+    return SpreadsheetCellReference.parse("A1");
 }
 
 function end() {
-    return new SpreadsheetCellReference("B2");
+    return SpreadsheetCellReference.parse("B2");
 }
 
 test("create without begin fails", () => {


### PR DESCRIPTION
- Introduced two properties replacing single String reference property.
- TODO SpreadsheetDelta use SpreadsheetColumnReference and SpreadsheetRowReference as keys to maxColumnWidths, maxRowHeights