### PR TITLE
SpreadsheetMetadata.spreadsheetId() absent no longer throws

### DIFF
--- a/src/spreadsheet/meta/SpreadsheetMetadata.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.js
@@ -296,7 +296,7 @@ export default class SpreadsheetMetadata {
     }
 
     spreadsheetId() {
-        return this.getOrFail(SPREADSHEET_ID);
+        return this.get(SPREADSHEET_ID);
     }
 
     spreadsheetName() {

--- a/src/spreadsheet/meta/SpreadsheetMetadata.test.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.test.js
@@ -487,11 +487,7 @@ test("equals same property values with defaults", () => {
 // helpers..............................................................................................................
 
 function checkSpreadsheetId(metadata, id) {
-    if (id) {
-        expect(metadata.spreadsheetId()).toBe(id);
-    } else {
-        expect(() => metadata.spreadsheetId()).toThrow("Missing \"spreadsheet-id\" " + metadata.toString());
-    }
+    expect(metadata.spreadsheetId()).toBe(id);
 }
 
 function checkSpreadsheetName(metadata, name) {


### PR DESCRIPTION
- Previously method called SpreadsheetMetadata.getOrFail changed to get