### PR TITLE
SpreadsheetRange parse lowercase support & cell fix

### DIFF
--- a/src/spreadsheet/reference/SpreadsheetRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRange.js
@@ -18,15 +18,23 @@ export default class SpreadsheetRange extends SpreadsheetRectangle{
             throw new Error("Expected string got " + text);
         }
 
-        let tokens = text.split(":");
-        if (2 !== tokens.length) {
-            throw new Error("Expected 2 tokens got " + text);
+        var range;
+        const tokens = text.split(":");
+        switch (tokens.length) {
+            case 1:
+                const cell = SpreadsheetCellReference.fromJson(tokens[0]);
+                range = new SpreadsheetRange(cell, cell);
+                break;
+            case 2:
+                range = new SpreadsheetRange(
+                    SpreadsheetCellReference.fromJson(tokens[0]),
+                    SpreadsheetCellReference.fromJson(tokens[1]));
+                break;
+            default:
+                throw new Error("Expected 1 or 2 tokens got " + text);
         }
 
-        return new SpreadsheetRange(
-            SpreadsheetCellReference.fromJson(tokens[0]),
-            SpreadsheetCellReference.fromJson(tokens[1])
-        );
+        return range;
     }
 
     constructor(begin, end) {
@@ -57,7 +65,11 @@ export default class SpreadsheetRange extends SpreadsheetRectangle{
     }
 
     toJson() {
-        return this.begin() + ":" + this.end();
+        const begin = this.begin();
+        const end = this.end();
+        return begin.equals(end) ?
+            begin.toJson() :
+            begin.toJson() + ":" + end.toJson();
     }
 
     equals(other) {

--- a/src/spreadsheet/reference/SpreadsheetRange.test.js
+++ b/src/spreadsheet/reference/SpreadsheetRange.test.js
@@ -29,12 +29,121 @@ test("create", () => {
     check(new SpreadsheetRange(begin(), end()), begin(), end(), "A1:B2");
 });
 
+// parse.............................................................................................................
+
+test("parse missing fails", () => {
+    expect(() => SpreadsheetRange.parse()).toThrow("Missing text");
+});
+
+test("parse null fails", () => {
+    expect(() => SpreadsheetRange.parse(null)).toThrow("Missing text");
+});
+
+test("parse empty fails", () => {
+    expect(() => SpreadsheetRange.parse("")).toThrow("Missing text");
+});
+
+test("parse wrong token count fails", () => {
+    expect(() => SpreadsheetRange.parse("A1:B2:C3")).toThrow("Expected 1 or 2 tokens got A1:B2:C3");
+});
+
+test("parse only cell", () => {
+    const range = SpreadsheetRange.parse("A2");
+    const cell = SpreadsheetCellReference.parse("A2");
+    check(range, cell, cell, "A2");
+});
+
+test("parse relative/relative", () => {
+    const range = SpreadsheetRange.parse("B3:C5");
+    const begin = SpreadsheetCellReference.parse("B3");
+    const end = SpreadsheetCellReference.parse("C5");
+    check(range, begin, end, "B3:C5");
+});
+
+test("parse absolute/absolute:relative", () => {
+    const range = SpreadsheetRange.parse("$D$6:E8");
+    const begin = SpreadsheetCellReference.parse("$D$6");
+    const end = SpreadsheetCellReference.parse("E8");
+    check(range, begin, end, "$D$6:E8");
+});
+
+test("parse absolute/relative:relative", () => {
+    const range = SpreadsheetRange.parse("$F$10:G11");
+    const begin = SpreadsheetCellReference.parse("$F$10");
+    const end = SpreadsheetCellReference.parse("G11");
+    check(range, begin, end, "$F$10:G11");
+});
+
+test("parse relative:absolute/absolute", () => {
+    const range = SpreadsheetRange.parse("H12:$I$13");
+    const begin = SpreadsheetCellReference.parse("H12");
+    const end = SpreadsheetCellReference.parse("$I$13");
+    check(range, begin, end, "H12:$I$13");
+});
+
+test("parse relative:absolute/relative", () => {
+    const range = SpreadsheetRange.parse("J14:$K14");
+    const begin = SpreadsheetCellReference.parse("J14");
+    const end = SpreadsheetCellReference.parse("$K14");
+    check(range, begin, end, "J14:$K14");
+});
+
+test("parse lowercase:uppercase", () => {
+    const range = SpreadsheetRange.parse("l15:M16");
+    const begin = SpreadsheetCellReference.parse("l15");
+    const end = SpreadsheetCellReference.parse("M16");
+    check(range, begin, end, "L15:M16");
+});
+
+test("parse lowercase:lowercase", () => {
+    const range = SpreadsheetRange.parse("n17:o18");
+    const begin = SpreadsheetCellReference.parse("n17");
+    const end = SpreadsheetCellReference.parse("o18");
+    check(range, begin, end, "N17:O18");
+});
+
+test("parse lowercase:lowercase/absolute", () => {
+    const range = SpreadsheetRange.parse("$p$19:$r$20");
+    const begin = SpreadsheetCellReference.parse("$p$19");
+    const end = SpreadsheetCellReference.parse("$r$20");
+    check(range, begin, end, "$P$19:$R$20");
+});
+
+// fromJson.............................................................................................................
+
 test("fromJson null fails", () => {
     expect(() => SpreadsheetRange.fromJson(null)).toThrow("Missing text");
 });
 
 test("fromJson wrong token count fails", () => {
-    expect(() => SpreadsheetRange.fromJson("A1:B2:C3")).toThrow("Expected 2 tokens got A1:B2:C3");
+    expect(() => SpreadsheetRange.fromJson("A1:B2:C3")).toThrow("Expected 1 or 2 tokens got A1:B2:C3");
+});
+
+test("fromJson only cell", () => {
+    const range = SpreadsheetRange.fromJson("A2");
+    const cell = SpreadsheetCellReference.parse("A2");
+    check(range, cell, cell, "A2");
+});
+
+test("fromJson range", () => {
+    const range = SpreadsheetRange.fromJson("B3:C5");
+    const begin = SpreadsheetCellReference.parse("B3");
+    const end = SpreadsheetCellReference.parse("C5");
+    check(range, begin, end, "B3:C5");
+});
+
+test("fromJson range absolute/relative", () => {
+    const range = SpreadsheetRange.fromJson("D$6:$E7");
+    const begin = SpreadsheetCellReference.parse("D$6");
+    const end = SpreadsheetCellReference.parse("$E7");
+    check(range, begin, end, "D$6:$E7");
+});
+
+test("fromJson range lowercase", () => {
+    const range = SpreadsheetRange.fromJson("f8:g9");
+    const begin = SpreadsheetCellReference.parse("f8");
+    const end = SpreadsheetCellReference.parse("g9");
+    check(range, begin, end, "F8:G9");
 });
 
 // equals...............................................................................................................


### PR DESCRIPTION
- SpreadsheetRange.toJson() fixed to support begin==end.
- SpreadsheetRange.parse( cell ) fixed.