### PR TITLE
SpreadsheetDrawerWidget "Encountered two children with the same key" …

### DIFF
--- a/src/spreadsheet/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/SpreadsheetDrawerWidget.js
@@ -139,7 +139,7 @@ class SpreadsheetDrawerWidget extends React.Component {
 
         // hover = highlight under mouse over
         return (
-        <TableRow key={row}
+        <TableRow key={label}
                   hover={true}>
             <TableCell className={classes.label}>{label}</TableCell>
             <TableCell id={id}


### PR DESCRIPTION
…warning fix

- Warning: Encountered two children with the same key, `[object Object]`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.