### PR TITLE
SpreadsheetDrawerWidget Each child in a list should have a unique "ke…

### DIFF
--- a/src/spreadsheet/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/SpreadsheetDrawerWidget.js
@@ -153,7 +153,8 @@ class SpreadsheetDrawerWidget extends React.Component {
     // TODO pass onChange to update history hash
     // TODO AccordionSummary aria-control
     accordion(id, expanded, onChange, classes, heading, secondaryHeading, children) {
-        return <Accordion id={id}
+        return <Accordion key={id}
+                          id={id}
                           expanded={expanded}
                           onChange={onChange}>
             <AccordionSummary


### PR DESCRIPTION
…y" prop warning fix

- Warning: Each child in a list should have a unique "key" prop.
  Check the render method of `SpreadsheetDrawerWidget`. See https://reactjs.org/link/warning-keys for more information.