### PR TITLE
SpreadsheetContainerWidget children "Failed prop type" warning fix

### DIFF
--- a/src/widget/SpreadsheetContainerWidget.js
+++ b/src/widget/SpreadsheetContainerWidget.js
@@ -26,5 +26,5 @@ export default class SpreadsheetContainerWidget extends React.Component {
 
 SpreadsheetContainerWidget.propTypes = {
     style: PropTypes.object.isRequired,
-    children: PropTypes.array.isRequired,
+    children: PropTypes.node.isRequired,
 }


### PR DESCRIPTION
- Failed prop type: Invalid prop `children` of type `object` supplied to `SpreadsheetContainerWidget`, expected `array`.
  at SpreadsheetContainerWidget (http://localhost:3000/static/js/main.chunk.js:8972:5)