### PR TITLE
SpreadsheetDrawerWidget Received false for a non boolean attribute mo…

### DIFF
--- a/src/spreadsheet/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/SpreadsheetDrawerWidget.js
@@ -59,7 +59,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                        anchor={"right"}
                        variant={"persistent"}
                        open={this.state.open}
-                       modal={false}
+                       modal={"false"}
                        onClose={this.onClose}
         >
             <div className={classes.root}


### PR DESCRIPTION
…dal warning fix

- Warning: Received `false` for a non-boolean attribute `modal`.
  If you want to write it to the DOM, pass a string instead: modal="false" or modal={value.toString()}.