### PR TITLE
FormatRequest.toJson value fix

### DIFF
--- a/src/spreadsheet/server/format/FormatRequest.js
+++ b/src/spreadsheet/server/format/FormatRequest.js
@@ -52,7 +52,7 @@ export default class FormatRequest extends SystemObject {
 
     toJson() {
         return {
-            value: this.value().toJsonWithType(),
+            value: SystemObject.toJsonWithType(this.value()),
             pattern: this.pattern().toJsonWithType(),
         };
     }

--- a/src/spreadsheet/server/format/FormatRequest.test.js
+++ b/src/spreadsheet/server/format/FormatRequest.test.js
@@ -1,6 +1,7 @@
 import FormatRequest from "./FormatRequest.js";
 import LocalDateTime from "../../../datetime/LocalDateTime.js";
 import SpreadsheetDateFormatPattern from "../../format/SpreadsheetDateFormatPattern.js";
+import SystemObject from "../../../SystemObject.js";
 import systemObjectTesting from "../../../SystemObjectTesting.js";
 
 function value() {
@@ -117,6 +118,20 @@ test("toJson", () => {
         .toStrictEqual(
             {
                 value: v.toJsonWithType(),
+                pattern: p.toJsonWithType(),
+            }
+        );
+});
+
+test("toJson string value", () => {
+    const v = "string-123";
+    const p = pattern();
+
+    expect(new FormatRequest(v, p)
+        .toJson())
+        .toStrictEqual(
+            {
+                value: SystemObject.toJsonWithType(v),
                 pattern: p.toJsonWithType(),
             }
         );


### PR DESCRIPTION
- Built in types (String etc) should now "work", no longer assumes toJsonWithType is present
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/409
- MultiFormatResponse