### PR TITLE
FormatRequest remove pattern type check

### DIFF
--- a/src/spreadsheet/server/format/FormatRequest.js
+++ b/src/spreadsheet/server/format/FormatRequest.js
@@ -35,9 +35,6 @@ export default class FormatRequest extends SystemObject {
         if(!pattern){
             throw new Error("Missing pattern");
         }
-        if(!(pattern instanceof SpreadsheetPattern)){
-            throw new Error("Expected SpreadsheetPattern pattern got " + pattern);
-        }
         this.valueValue = value;
         this.patternValue = pattern;
     }

--- a/src/spreadsheet/server/format/FormatRequest.test.js
+++ b/src/spreadsheet/server/format/FormatRequest.test.js
@@ -57,13 +57,6 @@ test("create missing null pattern fails", () => {
     ).toThrow("Missing pattern");
 });
 
-test("create invalid pattern type fails", () => {
-    const p = "invalid pattern";
-    expect(
-        () => new FormatRequest(value(), p)
-    ).toThrow("Expected SpreadsheetPattern pattern got " + p);
-});
-
 test("create value & pattern", () => {
     const v = value();
     const p = pattern();


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/446
- ParserRequest should validate parser type names