### PR TITLE
requests force charset=UTF-8

### DIFF
--- a/src/spreadsheet/message/SpreadsheetMessenger.js
+++ b/src/spreadsheet/message/SpreadsheetMessenger.js
@@ -77,7 +77,7 @@ export default class SpreadsheetMessenger {
         const headers = Object.assign({
             "Accept": "application/json",
             "Accept-Charset": "UTF-8",
-            "Content-Type": "application/json",
+            "Content-Type": "application/json;charset=UTF-8",
             "X-Transaction-ID": "" + transactionIdHeader,
         }, parameters.headers);
 


### PR DESCRIPTION
- Server was guesing ISO-8859-1 which was resulting in bad encoding of english pound sign.
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/459
- SpreadsheetMetadata currencySymbol (which should be pound) keeps adding characters