### PR TITLE
SpreadsheetMetadata.precision=0 fix

### DIFF
--- a/src/spreadsheet/meta/SpreadsheetMetadata.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.js
@@ -586,8 +586,8 @@ function checkPrecision(precision) {
     if(typeof precision !== "number"){
         throw new Error("Expected number precision got " + precision);
     }
-    if(precision <= 0){
-        throw new Error("Expected number precision > 0 got " + precision);
+    if(precision < 0){
+        throw new Error("Expected number precision >= 0 got " + precision);
     }
 }
 

--- a/src/spreadsheet/meta/SpreadsheetMetadata.test.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.test.js
@@ -327,12 +327,12 @@ getSetRemovePropertyTest(SpreadsheetMetadata.POSITIVE_SIGN, Character.fromJson("
 
 getSetRemovePropertyTest(SpreadsheetMetadata.PRECISION, 2);
 
-test("set precision 0 fails", () => {
-    expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, 0)).toThrow("Expected number precision > 0 got 0");
+test("set precision 0 pass", () => {
+    expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, 0));
 });
 
 test("set precision -1 fails", () => {
-    expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, -1)).toThrow("Expected number precision > 0 got -1");
+    expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, -1)).toThrow("Expected number precision >= 0 got -1");
 });
 
 getSetRemovePropertyTest(SpreadsheetMetadata.ROUNDING_MODE, RoundingMode.CEILING);


### PR DESCRIPTION
- Previously 0 was invalid, now allowed.