### PR TITLE
walkingkooka-tree-json/pull/106 JsonNodeContext.register LocalDateTim…

### DIFF
--- a/src/datetime/LocalDateTime.js
+++ b/src/datetime/LocalDateTime.js
@@ -4,7 +4,7 @@
  */
 import SystemObject from "../SystemObject.js";
 
-const TYPE_NAME = "local-datetime";
+const TYPE_NAME = "local-date-time";
 
 export default class LocalDateTime extends SystemObject {
 

--- a/src/datetime/LocalDateTime.test.js
+++ b/src/datetime/LocalDateTime.test.js
@@ -12,7 +12,7 @@ systemObjectTesting(
     new LocalDateTime("2000-1-1 1:01:01"),
     LocalDateTime.fromJson,
     "Missing text",
-    "local-datetime",
+    "local-date-time",
     text
 );
 


### PR DESCRIPTION
…e as "local-date-time" was "local-datetime"

- https://github.com/mP1/walkingkooka-tree-json/pull/106
- JsonNodeContext.register LocalDateTime as "local-date-time" was "local-datetime"