### PR TITLE
walkingkooka-tree-json/pull/106 JsonNodeContext.register LocalDateTim…

### DIFF
--- a/src/net/EmailAddress.js
+++ b/src/net/EmailAddress.js
@@ -1,6 +1,6 @@
 import SystemObject from "../SystemObject.js";
 
-const TYPE_NAME = "email";
+const TYPE_NAME = "email-address";
 /**
  * Holds a java EmailAddress in json form.
  * This assumes various services are used to validate/format this value.

--- a/src/net/EmailAddress.test.js
+++ b/src/net/EmailAddress.test.js
@@ -12,7 +12,7 @@ systemObjectTesting(
     new EmailAddress("different@example.com"),
     EmailAddress.fromJson,
     "Missing text",
-    "email",
+    "email-address",
     text
 );
 


### PR DESCRIPTION
…e as "local-date-time" was "local-datetime"

- https://github.com/mP1/walkingkooka-tree-json/pull/106
- JsonNodeContext.register LocalDateTime as "local-date-time" was "local-datetime"