### PR TITLE
Drawer improved label & default button widths etc

### DIFF
--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
@@ -61,7 +61,7 @@ const useStyles = theme => ({
     },
     label: {
         fontWeight: 700,
-        width: "150px",
+        width: "125px",
         verticalAlign: "middle",
     },
     value: {

--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidgetValue.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidgetValue.js
@@ -86,8 +86,13 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
                                             onClick={this.onSetDefaultValue.bind(this)}
                                             style={
                                                 {
+                                                    maxWidth: "64px",
+                                                    overflowX: "hidden",
+                                                    overflowY: "hidden",
+                                                    textOverflow: "ellipsis",
                                                     textTransform: "none",
                                                     visibility: null == defaultValue ? "hidden": null,
+                                                    whiteSpace: "nowrap",
                                                 }
                                             }
                                     >


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/539
- drawer (right) default button text overflow