### PR TITLE
Default button tooltip for patterns

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -295,6 +295,7 @@ context("General app usage", () => {
     function enterSpreadsheetMetadataTextAndCheck(property,
                                                   a1Formula,
                                                   text,
+                                                  defaultText,
                                                   a1CellContent,
                                                   a1CellContentDefault) {
         it("Show drawer and update SpreadsheetMetadata." + property, () => {
@@ -328,6 +329,7 @@ context("General app usage", () => {
 
             const buttonId = "#spreadsheet-metadata-" + property + "-default-button";
             cy.get(buttonId)
+                .should("have.text", defaultText)
                 .click();
 
             cy.get(textFieldId)
@@ -343,6 +345,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.DATE_FORMAT_PATTERN,
         "31/12/1999",
         "yyyy/mm/dd",
+        "Default",
         "0.001", // TODO verify date was reformatted.
         "0.001",
     );
@@ -350,6 +353,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.DATE_PARSE_PATTERNS,
         "31/12/1999",
         "yyyy/mm/dd",
+        "Default",
         "0.001", // TODO verify date was reformatted.
         "0.001",
     );
@@ -357,6 +361,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.DATETIME_FORMAT_PATTERN,
         "31/12/1999 12:58:59",
         "yyyy/mm/dd hh:mm:ss",
+        "Default",
         "", // TODO verify date/time was reformatted. formula entry currently results in a formula parsing exception
         "",
     );
@@ -364,6 +369,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.DATETIME_PARSE_PATTERNS,
         "31/12/1999 12:58:59",
         "yyyy/mm/dd hh:mm:ss",
+        "Default",
         "", // TODO enter formula and verify date/time was parsed correctly. formula entry currently results in a formula parsing exception
         "",
     );
@@ -371,18 +377,21 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.DECIMAL_SEPARATOR,
         "5/2",
         "d",
+        ".",
         "2d5", // 5.2 decimal separator now capital D
         "2.5",
     );
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.EXPONENT_SYMBOL,
         null,
         "x",
+        "E",
         null,
         null);
 
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.GROUPING_SEPARATOR,
         "123456",
         "g",
+        ",",
         "123g456.",
         "123,456."
     );
@@ -390,12 +399,14 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.NEGATIVE_SIGN,
         "2*-4",
         "n",
+        "-",
         "n8.",
         "-8.");
 
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.NUMBER_FORMAT_PATTERN,
         "123.5",
         "###.000",
+        "Default",
         "123.500", // TODO verify number was reformatted.
         "123.5",
     );
@@ -403,6 +414,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.NUMBER_PARSE_PATTERNS,
         "123.5",
         "###.000",
+        "Default",
         "123.5", // TODO verify number entry compat with pattern
         "123.5",
     );
@@ -411,6 +423,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.PERCENTAGE_SYMBOL,
         null,
         "p",
+        "%",
         null,
         null);
 
@@ -418,6 +431,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.POSITIVE_SIGN,
         null,
         "o",
+        "+",
         null,
         null,
     );
@@ -425,6 +439,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.TEXT_FORMAT_PATTERN,
         "\"Hello 123\"",
         "@@",
+        "Default",
         "Hello 123Hello 123",
         "Hello 123",
     );
@@ -432,6 +447,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.TIME_FORMAT_PATTERN,
         "12:58:59", // formula parsing fails on time
         "hh:mm:ss",
+        "Default",
         "", // TODO verify time was reformatted.
         "",
     );
@@ -439,6 +455,7 @@ context("General app usage", () => {
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.TIME_PARSE_PATTERNS,
         "12:58:59", // formula parsing fails on time
         "hh:mm:ss",
+        "Default",
         "", // TODO enter formula using new pattern
         "",
     );

--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
@@ -383,6 +383,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                            value={value}
                                                            defaultValue={defaultValue}
                                                            defaultValueFormatter={(s) => s}
+                                                           defaultButtonTooltip={false}
                                                            setValue={setValue}
                             />
                         );
@@ -392,6 +393,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                       value={value}
                                                                                       defaultValue={defaultValue}
                                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                      defaultButtonTooltip={true}
                                                                                       setValue={setValue}
                             />;
                         break;
@@ -400,6 +402,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                       value={value}
                                                                                       defaultValue={defaultValue}
                                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                      defaultButtonTooltip={true}
                                                                                       setValue={setValue}
                         />;
                         break;
@@ -408,6 +411,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                           value={value}
                                                                                           defaultValue={defaultValue}
                                                                                           defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                          defaultButtonTooltip={true}
                                                                                           setValue={setValue}
                         />;
                         break;
@@ -416,6 +420,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                           value={value}
                                                                                           defaultValue={defaultValue}
                                                                                           defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                          defaultButtonTooltip={true}
                                                                                           setValue={setValue}
                         />;
                         break;
@@ -430,6 +435,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                               value={value}
                                                               defaultValue={defaultValue}
                                                               defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                              defaultButtonTooltip={false}
                                                               setValue={setValue}
                             />
                         );
@@ -455,7 +461,9 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                 value={value}
                                                                 defaultValue={defaultValue}
                                                                 defaultValueFormatter={DEFAULT_VALUE_FORMATTER_LABEL}
-                                                                setValue={setValue}/>;
+                                                                defaultButtonTooltip={false}
+                                                                setValue={setValue}
+                        />;
                         break;
                     case SpreadsheetMetadata.DATETIME_OFFSET:
                     case SpreadsheetMetadata.PRECISION:
@@ -576,13 +584,16 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                    value={numberValue}
                                                                                    defaultValue={defaultValue}
                                                                                    defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
-                                                                                   setValue={setValue}/>;
+                                                                                   defaultButtonTooltip={false}
+                                                                                   setValue={setValue}
+                        />;
                         break;
                     case SpreadsheetMetadata.NUMBER_FORMAT_PATTERN:
                         render = <SpreadsheetDrawerWidgetSpreadsheetNumberFormatPattern id={id}
                                                                                         value={value}
                                                                                         defaultValue={defaultValue}
                                                                                         defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                        defaultButtonTooltip={true}
                                                                                         setValue={setValue}
                         />;
                         break;
@@ -591,6 +602,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                         value={value}
                                                                                         defaultValue={defaultValue}
                                                                                         defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                        defaultButtonTooltip={true}
                                                                                         setValue={setValue}
                         />;
                         break;
@@ -609,13 +621,16 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                       value={value}
                                                                       defaultValue={defaultValue}
                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_LABEL}
-                                                                      setValue={setValue}/>;
+                                                                      defaultButtonTooltip={false}
+                                                                      setValue={setValue}
+                        />;
                         break;
                     case SpreadsheetMetadata.TEXT_FORMAT_PATTERN:
                         render = <SpreadsheetDrawerWidgetSpreadsheetTextFormatPattern id={id}
                                                                                       value={value}
                                                                                       defaultValue={defaultValue}
                                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                      defaultButtonTooltip={true}
                                                                                       setValue={setValue}
                         />;
                         break;
@@ -624,6 +639,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                       value={value}
                                                                                       defaultValue={defaultValue}
                                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                      defaultButtonTooltip={true}
                                                                                       setValue={setValue}
                         />;
                         break;
@@ -632,6 +648,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                       value={value}
                                                                                       defaultValue={defaultValue}
                                                                                       defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                                      defaultButtonTooltip={true}
                                                                                       setValue={setValue}
                         />;
                         break;

--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidgetValue.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidgetValue.js
@@ -4,6 +4,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import PropTypes from "prop-types";
 import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
 
 /**
  * A base class that calls a renderInput method during a render adding a button to set the default value to the right.
@@ -19,6 +20,7 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
                 defaultValue: valueType, // Character: this value is set when the default button is clicked.
                 defaultValueFormatter: PropTypes.func.isRequired, // Used to convert the default value if one is present into text
                 setValue: PropTypes.func.isRequired, // if present editing/updates to the value are supported.
+                defaultButtonTooltip: PropTypes.bool.isRequired, // when true a tooltip will appear over the default button.
             },
             extraProps
         );
@@ -36,6 +38,7 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
         this.initialValue = initialValue; // ESCAPE will reload the default.
         this.defaultValue = props.defaultValue;
         this.defaultValueFormatter= props.defaultValueFormatter;
+        this.defaultButtonTooltip = props.defaultButtonTooltip;
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
@@ -58,7 +61,6 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
 
         console.log("render id=" + id + " value=" + value + " defaultValue=" + defaultValue);
 
-        const defaultButtonId = id + "-default-button";
         return (
             <div>
                 <div>
@@ -78,26 +80,7 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
                             {
                                 [
                                     this.renderInput(id, value),
-                                    <Button id={defaultButtonId}
-                                            key={defaultButtonId}
-                                            variant="contained"
-                                            color="primary"
-                                            size="small"
-                                            onClick={this.onSetDefaultValue.bind(this)}
-                                            style={
-                                                {
-                                                    maxWidth: "64px",
-                                                    overflowX: "hidden",
-                                                    overflowY: "hidden",
-                                                    textOverflow: "ellipsis",
-                                                    textTransform: "none",
-                                                    visibility: null == defaultValue ? "hidden": null,
-                                                    whiteSpace: "nowrap",
-                                                }
-                                            }
-                                    >
-                                        {this.defaultValueFormatter(defaultValue)}
-                                    </Button>
+                                    this.renderDefaultButton(id + "-default-button", defaultValue),
                                 ]
                             }
                         </ListItem>
@@ -112,6 +95,36 @@ export default class SpreadsheetDrawerWidgetValue extends React.Component {
      */
     renderInput(id, value) {
         throw new Error("renderInput not overridden");
+    }
+
+    renderDefaultButton(id, value) {
+        const defaultButtonTooltip = this.defaultButtonTooltip;
+        const text = this.defaultValueFormatter(value);
+
+        const button = <Button id={id}
+                               key={id}
+                               variant="contained"
+                               color="primary"
+                               size="small"
+                               onClick={this.onSetDefaultValue.bind(this)}
+                               style={
+                                   {
+                                       maxWidth: "64px",
+                                       overflowX: "hidden",
+                                       overflowY: "hidden",
+                                       textOverflow: "ellipsis",
+                                       textTransform: "none",
+                                       visibility: null == value ? "hidden" : null,
+                                       whiteSpace: "nowrap",
+                                   }
+                               }
+        >
+            {defaultButtonTooltip ? "Default" : text}
+        </Button>;
+
+        return defaultButtonTooltip ?
+            <Tooltip key={id + "-Tooltip"} title={text}>{button}</Tooltip> :
+            button;
     }
 
     /**


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/547
- Tooltip above default button showing full "text" (pattern) for long SpreadsheetMetadata in drawer
- Unfortunately cypress does not include a hover command, so tooltip hovering and appear cannot be tested.