### PR TITLE
SpreadsheetMetadata.TEXT_FORMAT_PATTERN apostrophe string fix

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -453,7 +453,7 @@ context("General app usage", () => {
     );
 
     enterSpreadsheetMetadataTextAndCheck(SpreadsheetMetadata.TEXT_FORMAT_PATTERN,
-        "'Hello",
+        "'Hello 123",
         "@@",
         "Default",
         "Hello 123Hello 123",


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/572
- Test: Show drawer and update SpreadsheetMetadata.text-format-pattern broken with formula=apostrophe string