### PR TITLE
Settings DATE_TIME_OFFSET props warning string fix

### DIFF
--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
@@ -602,6 +602,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                             default:
                                 break;
                         }
+                        // DATE_TIME_OFFSET defaultValue also requires string -> number
                         render = <SpreadsheetDrawerWidgetSliderWithNumberTextField id={id}
                                                                                    style={style}
                                                                                    min={min}
@@ -609,7 +610,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                                                                                    marks={marks}
                                                                                    step={step}
                                                                                    value={numberValue}
-                                                                                   defaultValue={defaultValue}
+                                                                                   defaultValue={typeof defaultValue === "string" ? parseInt(defaultValue) : defaultValue}
                                                                                    defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
                                                                                    defaultButtonTooltip={false}
                                                                                    setValue={setValue}


### PR DESCRIPTION
- long value of DATE_TIME_OFFSET is a string, needed conversion to number to satisfy prop types for SpreadsheetDrawerWidgetSliderWithNextTextField.