### PR TITLE
SpreadsheetMetadata.DATETIME_OFFSET drawer corruption fix

### DIFF
--- a/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
+++ b/src/spreadsheet/drawer/SpreadsheetDrawerWidget.js
@@ -484,7 +484,7 @@ class SpreadsheetDrawerWidget extends React.Component {
                         var step;
                         switch(property) {
                             case SpreadsheetMetadata.DATETIME_OFFSET:
-                                numberValue = parseInt(value);
+                                numberValue = typeof value == "string" ? parseInt(value) : value;
                                 min = -25569;
                                 max = -24107;
                                 marks = [


### PR DESCRIPTION
- Missing Value was being saved as a number rather than undefined when another property was saved.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/610
- SpreadsheetMetadata date-time-offset corrupted whens saved