### PR TITLE
SpreadsheetHistoryHash replace outstanding hash pathname parsing/buil…

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -112,7 +112,11 @@ class SpreadsheetSettingsWidget extends React.Component {
     }
 
     componentDidMount() {
-        this.history.listen(this.onHistoryChange.bind(this));
+        this.historyUnlisten = this.history.listen(this.onHistoryChange.bind(this));
+    }
+
+    componentWillUnmount() {
+        this.historyUnlisten();
     }
 
     /**


### PR DESCRIPTION
…ding

- Replace outstanding hash pathname parsing and building with SpreadsheetHistoryHash
- history listener removed when component unmounts.
- App minimal history hash awareness only updates SpreadsheetFormulaWidget and SpreadsheetViewportWidget when cells loaded.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/640
- adding "edit" to history hash doesnt make name editable