### PR TITLE
Settings: label "Exponent symbol" was "Exponent Symbol"

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -788,7 +788,7 @@ class SpreadsheetSettingsWidget extends React.Component {
                 label = "Default year";
                 break;
             case SpreadsheetMetadata.EXPONENT_SYMBOL :
-                label = "Exponent Symbol";
+                label = "Exponent symbol";
                 break;
             case SpreadsheetMetadata.EXPRESSION_NUMBER_KIND :
                 label = "Number";


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/709
- Settings text: Exponent Symbol -> Exponent symbol