### PR TITLE
SpreadsheetMetadata improved number property check

### DIFF
--- a/src/spreadsheet/meta/SpreadsheetMetadata.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.js
@@ -716,7 +716,7 @@ function checkPrecision(precision) {
     if(typeof precision !== "number"){
         throw new Error("Expected number precision got " + precision);
     }
-    if(precision < 0){
+    if(!(precision > 0)){
         throw new Error("Expected number precision >= 0 got " + precision);
     }
 }

--- a/src/spreadsheet/meta/SpreadsheetMetadata.test.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.test.js
@@ -537,6 +537,10 @@ test("set precision -1 fails", () => {
     expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, -1)).toThrow("Expected number precision >= 0 got -1");
 });
 
+test("set precision NAN fails", () => {
+    expect(() => SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadata.PRECISION, parseInt(undefined))).toThrow("Expected number precision >= 0 got NaN");
+});
+
 getSetRemovePropertyTest(SpreadsheetMetadata.ROUNDING_MODE, RoundingMode.CEILING);
 
 getPropertyTest(SpreadsheetMetadata.SPREADSHEET_ID, "123");


### PR DESCRIPTION
- Correctly fail if value is NAN.