### PR TITLE
Cell cursor key navigation

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -181,6 +181,35 @@ context(
             cellFormattedTextCheck("F6", "6.");
         });
 
+        it("Select cell and navigate using arrow keys", () => {
+            reactRenderWait();
+
+            cellClick("C3");
+            cellGet("C3")
+                .type("{leftarrow}");
+
+            hash()
+                .should('match', /.*\/.*\/cell\/B3\/formula/)
+
+            cellGet("B3")
+                .type("{rightarrow}");
+
+            hash()
+                .should('match', /.*\/.*\/cell\/C3\/formula/)
+
+            cellGet("C3")
+                .type("{uparrow}");
+
+            hash()
+                .should('match', /.*\/.*\/cell\/C2\/formula/)
+
+            cellGet("C2")
+                .type("{downarrow}");
+
+            hash()
+                .should('match', /.*\/.*\/cell\/C3\/formula/)
+        });
+
         // SETTINGS.........................................................................................................
 
         it("Toggle(Show and hide) settings", () => {
@@ -1403,7 +1432,13 @@ context(
          */
         function cellClick(cellReference) {
             cellGet(cellReference)
-                .click()
+                .click();
+
+            cellOutlined(cellReference);
+        }
+
+        function cellOutlined(cellReference) {
+            cellGet(cellReference)
                 .should("have.css", "outline-color", "rgb(0, 0, 0)")
                 .should("have.css", "outline-style", "dotted")
                 .should("have.css", "outline-width", "3px");

--- a/src/spreadsheet/SpreadsheetCell.js
+++ b/src/spreadsheet/SpreadsheetCell.js
@@ -149,7 +149,7 @@ export default class SpreadsheetCell extends SystemObject {
     /**
      * Renders a TableCell with the formatted content. The default style will typically come from {@link SpreadsheetMetadata}.
      */
-    render(defaultStyle, edit, onClick) {
+    render(defaultStyle, edit, onClick, onKeyDown) {
         if(!defaultStyle){
             throw new Error("Missing defaultStyle");
         }
@@ -178,6 +178,8 @@ export default class SpreadsheetCell extends SystemObject {
                           id={"cell-" + reference}
                           className={"cell"}
                           onClick={onClick}
+                          onKeyDown={onKeyDown}
+                          tabIndex={edit ? -1 : undefined}
                           style={css}>{formattedRender}</TableCell>;
     }
 

--- a/src/spreadsheet/SpreadsheetCell.test.js
+++ b/src/spreadsheet/SpreadsheetCell.test.js
@@ -41,6 +41,9 @@ function onClick() {
     return true;
 }
 
+function onKeyDown() {
+}
+
 systemObjectTesting(
     cell(),
     new SpreadsheetCell(
@@ -309,16 +312,18 @@ test("render empty style, text & defaultStyle EMPTY", () => {
     const text = "text-abc123";
     const ref = reference();
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(ref,
         formula(),
         TextStyle.EMPTY,
         format(),
         new Text(text))
-        .render(TextStyle.EMPTY, NOT_EDITING, c))
+        .render(TextStyle.EMPTY, NOT_EDITING, c, kd))
         .toStrictEqual(<TableCell key={ref}
                                   id="cell-A99"
                                   onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box"}}>{text}</TableCell>);
 });
@@ -327,16 +332,18 @@ test("render empty style, text & defaultStyle EMPTY 2", () => {
     const text = "text-abc123";
     const ref = SpreadsheetCellReference.parse("B123");
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(ref,
         formula(),
         TextStyle.EMPTY,
         format(),
         new Text(text))
-        .render(TextStyle.EMPTY, NOT_EDITING, c))
+        .render(TextStyle.EMPTY, NOT_EDITING, c, kd))
         .toStrictEqual(<TableCell key={ref}
                                   id="cell-B123"
                                   onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box"}}>{text}</TableCell>);
 });
@@ -345,6 +352,7 @@ test("render empty style, text & defaultStyle width&height", () => {
     const text = "text-abc123";
     const r = reference();
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(r,
         formula(),
@@ -356,10 +364,12 @@ test("render empty style, text & defaultStyle width&height", () => {
                 .set("width", lengthFromJson("100px"))
                 .set("height", lengthFromJson("50px")),
             NOT_EDITING,
-            c))
+            c,
+            kd))
         .toStrictEqual(<TableCell key={r}
                                   id="cell-A99"
                                   onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box", width: "100px", height: "50px"}}>{text}</TableCell>);
 });
@@ -368,6 +378,7 @@ test("render style=width&height, text & defaultStyle=empty", () => {
     const text = "text-abc123";
     const r = reference();
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(r,
         formula(),
@@ -376,10 +387,11 @@ test("render style=width&height, text & defaultStyle=empty", () => {
             .set("height", lengthFromJson("50px")),
         format(),
         new Text(text))
-        .render(TextStyle.EMPTY, NOT_EDITING, c))
+        .render(TextStyle.EMPTY, NOT_EDITING, c, kd))
         .toStrictEqual(<TableCell key={r}
                                   id="cell-A99"
                                   onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box", width: "100px", height: "50px"}}>{text}</TableCell>);
 });
@@ -388,6 +400,7 @@ test("render style=height, text & defaultStyle=width", () => {
     const text = "text-abc123";
     const r = reference();
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(r,
         formula(),
@@ -398,10 +411,12 @@ test("render style=height, text & defaultStyle=width", () => {
         .render(TextStyle.EMPTY
                 .set("width", lengthFromJson("100px")),
             NOT_EDITING,
-            c))
+            c,
+            kd))
         .toStrictEqual(<TableCell key={r}
                                   id="cell-A99"
                                   onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box", width: "100px", height: "50px"}}>{text}</TableCell>);
 });
@@ -410,6 +425,7 @@ test("render style=width&height, text & defaultStyle=width", () => {
     const text = "text-abc123";
     const r = reference();
     const c = onClick;
+    const kd = onKeyDown;
 
     expect(new SpreadsheetCell(r,
         formula(),
@@ -421,9 +437,12 @@ test("render style=width&height, text & defaultStyle=width", () => {
         .render(TextStyle.EMPTY
                 .set("width", lengthFromJson("99px")),
             NOT_EDITING,
-            c))
+            c,
+            kd))
         .toStrictEqual(<TableCell id="cell-A99"
-                                  key={r} onClick={c}
+                                  key={r}
+                                  onClick={c}
+                                  onKeyDown={kd}
                                   className={"cell"}
                                   style={{boxSizing: "border-box", width: "100px", height: "50px"}}>{text}</TableCell>);
 });

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -131,6 +131,11 @@ export default class SpreadsheetViewportWidget extends React.Component {
             if(current !== updatedPathname){
                 history.push(updatedPathname);
             }
+
+            const cellElement = document.getElementById("cell-" + editCellNew);
+            if(cellElement) {
+                cellElement.focus();
+            }
         }
     }
 
@@ -237,11 +242,14 @@ export default class SpreadsheetViewportWidget extends React.Component {
                     console.log("SpreadsheetViewportWidget cell " + cellReference, cellReference, cell);
                 }
 
+                const editing = cellReference.equals(editCell);
+
                 tableCells.push(
                     cell.render(
                         defaultStyle,
-                        cellReference.equals(editCell),
-                        () => this.onCellClick(cellReference)
+                        editing,
+                        () => this.onCellClick(cellReference),
+                        editing ? (event) => this.onCellKeyDown(event, cellReference) : undefined,
                     )
                 );
 
@@ -297,9 +305,42 @@ export default class SpreadsheetViewportWidget extends React.Component {
     onCellClick(cellReference) {
         console.log("onCellClick: " + cellReference);
 
+        this.saveEditCell(cellReference);
+    }
+
+    onCellKeyDown(event, cellReference) {
+        event.preventDefault();
+
+        const key = event.key;
+        console.log("@@onCellKeyDown: " + cellReference + " key: " + key);
+
+        switch(key) {
+            case "ArrowLeft":
+                this.saveEditCell(cellReference.addColumnSaturated(-1));
+                break;
+            case "ArrowDown":
+                this.saveEditCell(cellReference.addRowSaturated(+1));
+                break;
+            case "ArrowRight":
+                this.saveEditCell(cellReference.addColumnSaturated(+1));
+                break;
+            case "ArrowUp":
+                this.saveEditCell(cellReference.addRowSaturated(-1));
+                break;
+            default:
+                // ignore other keys
+                break;
+        }
+    }
+
+    /**
+     * Saves the new edit cell, this should trigger any changes to the viewport including loading new cells
+     * scrolling etc.
+     */
+    saveEditCell(cellReference) {
         this.setState({
             editCell: cellReference,
-        })
+        });
     }
 }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/315
- keyboard navigation around cell viewport