### PR TITLE
SpreadsheetHistoryHash.parseMergeAndPush returns merged tokens

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -79,26 +79,15 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
         console.log("historyTokensFromState cell: " + cellOld + " to " + cellNew);
 
         if(!Equality.safeEquals(cellOld, cellNew)){
-            const history = this.history;
-            const current = history.location.pathname;
-
             const replacement = {};
             replacement[SpreadsheetHistoryHash.CELL] = cellNew;
+            const tokens = SpreadsheetHistoryHash.parseMergeAndPush(this.history, replacement);
 
-            const tokens = SpreadsheetHistoryHash.parse(current);
-            const updatedPathname = SpreadsheetHistoryHash.merge(
-                tokens,
-                replacement
-            );
-            console.log("historyTokensFromState current: " + current + " to " + updatedPathname);
-            if(current !== updatedPathname){
-                history.push(updatedPathname);
-            }
+            if(!tokens[SpreadsheetHistoryHash.CELL_FORMULA]){
+                console.log("Missing " + SpreadsheetHistoryHash.CELL_FORMULA + " token giving focus to cell...", tokens);
 
-            if(!tokens[SpreadsheetHistoryHash.CELL_FORMULA]) {
-                console.log("Missing formula token giving focus to cell...", tokens);
                 const cellElement = document.getElementById("cell-" + cellNew);
-                if(cellElement) {
+                if(cellElement){
                     cellElement.focus();
                 }
             }

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -13,24 +13,6 @@ function split(pathname) {
     return components;
 }
 
-function join(tokens) {
-    if(!tokens){
-        throw new Error("Missing tokens");
-    }
-    var s = "";
-    for(var i = 0; i < tokens.length; i++) {
-        const token = tokens[i];
-
-        // stop joining if a undefined/null token is found.
-        if(!token && token !== ""){
-            break;
-        }
-        s = s + "/" + token;
-    }
-
-    return s === "" ? "/" : s;
-}
-
 function isSettingsToken(token) {
     var valid;
 
@@ -195,7 +177,7 @@ export default class SpreadsheetHistoryHash {
     }
 
     /**
-     * Merges the tokens from the given current history hash tokens and the updates.
+     * Merges the current tokens with the replacements giving the merged result as another object.
      */
     static merge(current, replacements) {
         // get the current
@@ -295,11 +277,11 @@ export default class SpreadsheetHistoryHash {
             }
         }
 
-        return join(verified);
+        return verified;
     }
 
     /**
-     * Parses the current history hash, merges the replacements and pushes the new hash.
+     * Parses the current history hash, merges the replacements and pushes the new hash and returns the merged tokens.
      */
     static parseMergeAndPush(history, replacements) {
         if(null == history){
@@ -309,17 +291,39 @@ export default class SpreadsheetHistoryHash {
         const currentPathname = history.location.pathname;
         const tokens = SpreadsheetHistoryHash.parse(currentPathname);
 
-        const updatedPathname = SpreadsheetHistoryHash.merge(
+        const merged = SpreadsheetHistoryHash.merge(
             tokens,
             replacements
         );
+        const updatedPathname = SpreadsheetHistoryHash.join(merged);
         if(currentPathname !== updatedPathname){
             console.log("parseMergeAndPush history push \"" + currentPathname + "\"");
             history.push(updatedPathname);
         }else {
             console.log("parseMergeAndPush history unchanged \"" + currentPathname + "\" new \"" + updatedPathname + "\"");
         }
+
+        return merged;
     }
+
+    static join(tokens) {
+        if(!tokens){
+            throw new Error("Missing tokens");
+        }
+        var s = "";
+        for(var i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
+
+            // stop joining if a undefined/null token is found.
+            if(!token && token !== ""){
+                break;
+            }
+            s = s + "/" + token;
+        }
+
+        return s === "" ? "/" : s;
+    }
+
 
     constructor(history) {
         if(null == history){

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -1271,6 +1271,8 @@ test("replacements #2", () => {
 // helpers...............................................................................................................
 
 function mergeAndCheck(pathname, replacements, expected) {
-    expect(SpreadsheetHistoryHash.merge(SpreadsheetHistoryHash.parse(pathname), replacements))
+    expect(SpreadsheetHistoryHash.join(
+        SpreadsheetHistoryHash.merge(SpreadsheetHistoryHash.parse(pathname), replacements))
+    )
         .toStrictEqual(expected);
 }


### PR DESCRIPTION
- SpreadsheetViewportWidget updated to use SpreadsheetHistoryHash.parseMergeAndPush
- SpreadsheetHistoryHash.join added to assist testing.