### PR TITLE
SpreadsheetHistoryAwareWidget.showError()

### DIFF
--- a/src/spreadsheet/SpreadsheetFormulaWidget.js
+++ b/src/spreadsheet/SpreadsheetFormulaWidget.js
@@ -107,7 +107,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareWid
                     reload: false,
                 });
 
-                this.props.showError(e);
+                this.showError(e);
             });
     }
 
@@ -207,6 +207,10 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareWid
         const value = event.target.value;
         this.props.setValue(this.state.reference, value);
         this.setState({"value": value});
+    }
+
+    showError(message) {
+        this.props.showError(message);
     }
 }
 

--- a/src/spreadsheet/SpreadsheetNameWidget.js
+++ b/src/spreadsheet/SpreadsheetNameWidget.js
@@ -61,6 +61,10 @@ export default class SpreadsheetNameWidget extends SpreadsheetHistoryAwareWidget
         replacements[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = !this.isEdit();
         this.historyParseMergeAndPush(replacements);
     }
+
+    showError(message) {
+        this.props.showError(message);
+    }
 }
 
 SpreadsheetNameWidget.propTypes = {

--- a/src/spreadsheet/history/SpreadsheetHistoryAwareStateWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareStateWidget.js
@@ -21,8 +21,8 @@ export default class SpreadsheetHistoryAwareStateWidget extends SpreadsheetHisto
             this.initialStateFromProps(props),
             this.stateFromHistoryTokens(
                 SpreadsheetHistoryHash.parse(
-                    this.props.history.location.pathname,
-                    props.showError,
+                    props.history.location.pathname,
+                    this.showError.bind(this),
                 )
             )
         );
@@ -69,6 +69,10 @@ export default class SpreadsheetHistoryAwareStateWidget extends SpreadsheetHisto
      */
     historyTokensFromState(prevState) {
         throw new Error("Sub classes must override historyTokensFromState()");
+    }
+
+    showError(message) {
+        this.props.showError(message);
     }
 }
 

--- a/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
@@ -22,7 +22,7 @@ export default class SpreadsheetHistoryAwareWidget extends React.Component {
             (location) => this.onHistoryChange(
                 SpreadsheetHistoryHash.parse(
                     location.pathname,
-                    this.props.showError
+                    this.showError.bind(this)
                 )
             )
         );
@@ -42,11 +42,15 @@ export default class SpreadsheetHistoryAwareWidget extends React.Component {
         SpreadsheetHistoryHash.parseMergeAndPush(
             this.props.history,
             tokens,
-            this.props.showError);
+            this.showError.bind(this)
+        );
+    }
+
+    showError(message) {
+        throw new Error("Sub classes must override showError");
     }
 }
 
 SpreadsheetHistoryAwareWidget.propTypes = {
     history: PropTypes.object.isRequired,
-    showError: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
- method replaces direct references to props.showError