### PR TITLE
Unnecessary settings format createDateTime, lastModifiedDateTime fix

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -771,13 +771,10 @@ context(
                 .should("matches", /.*\/Untitled\/cell\/F6\/settings/);
         });
 
-        it("Show settings check creator-date-time/modified-date-time", () => {
+        it("Settings metadata check creator-date-time/modified-date-time", () => {
             emptySpreadsheetWait();
-
             settingsToggle();
-
-            settings()
-                .should('be.visible');
+            settingsOpenSectionSpreadsheetMetadataProperty(SpreadsheetMetadata.CREATE_DATE_TIME);
 
             const year = new Date().getFullYear();
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1615
- rpc for Format create/last modified still performed even though settings are not visible

- TODO handle format RPC errors.