### PR TITLE
Lost viewport refresh fix

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -575,17 +575,27 @@ context(
         it("Update then create new empty spreadsheet then reload non empty", () => {
             emptySpreadsheetWait();
 
-            cellClick("F6");
+            cy.window()
+                .then(function(win) {
+                    const nonEmptySpreadsheetHash = win.location.hash;
 
-            formulaText()
-                .type("=1+2+3")
-                .type("{enter}");
+                    cellClick("F6");
+
+                    formulaText()
+                        .type("=1+2+3")
+                        .type("{enter}");
 
 
-            hashEnter("/");
-            cy.go('back');
+                    emptySpreadsheetWait();
 
-            cellFormattedTextCheck("F6", "6.");
+                    // reload previous spreadsheet and verify viewport reloaded
+                    hashEnter(nonEmptySpreadsheetHash);
+
+                    hash()
+                        .should('eq', nonEmptySpreadsheetHash);
+
+                    cellFormattedTextCheck("F6", "6.");
+                });
         });
 
         it("Select cell should have focus", () => {


### PR DESCRIPTION
- eg updating hash to different/empty spreadsheet doesnt reload viewport cells.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/875
- Changing to a previous spreadsheet id (with cells) doesnt fill viewport cells with values