### PR TITLE
save spreadsheet success failure parameters

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -50,7 +50,67 @@ context(
             invalidHashUpdateRejected("/name/!invalid-name-action");
         });
 
-        it("Edit spreadsheet name", () => {
+        it("Edit spreadsheet name & ESCAPE", () => {
+            emptySpreadsheetWait();
+            spreadsheetNameClick();
+
+            const updatedSpreadsheetName = "SpreadsheetName234"; // easier to use in regex below
+
+            // type the new name in
+            spreadsheetName()
+                .type("{selectall}")
+                .type("UpdatedSpreadsheetName456")
+                .type("{esc}");
+
+            reactRenderWait();
+
+            spreadsheetName()
+                .should("have.text", "Untitled");
+            title()
+                .should("eq", "Untitled");
+            hash()
+                .should('match', /.*\/Untitled/) // => true
+        });
+
+        it("Edit spreadsheet name & blur", () => {
+            emptySpreadsheetWait();
+            spreadsheetNameClick();
+
+            // type the new name in
+            spreadsheetName()
+                .type("{selectall}")
+                .type("UpdatedSpreadsheetName456")
+                .blur();
+
+            reactRenderWait();
+
+            spreadsheetName()
+                .should("have.text", "Untitled");
+            title()
+                .should("eq", "Untitled");
+            hash()
+                .should('match', /.*\/Untitled/) // => true
+        });
+
+        it("Edit spreadsheet name & save empty fails", () => {
+            emptySpreadsheetWait();
+            spreadsheetNameClick();
+
+            // type the new name in
+            spreadsheetName()
+                .type("{selectall}")
+                .type("{backspace}")
+                .type("{enter}");
+
+            reactRenderWait();
+
+            spreadsheetName()
+                .should("have.text", "Untitled");
+            title().should("eq", "Untitled");
+            hash().should('match', /.*\/Untitled/) // => true
+        });
+
+        it("Edit spreadsheet name & save", () => {
             emptySpreadsheetWait();
             spreadsheetNameClick();
 

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -160,7 +160,15 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
         }
 
         if(!metadata.equals(prevState.spreadsheetMetadata)){
-            this.props.setSpreadsheetMetadata(metadata);
+            this.props.setSpreadsheetMetadata(
+                metadata,
+                (m) => {
+                    this.setState({
+                        spreadsheetMetadata: m,
+                    });
+                },
+                (e) => this.showError(e),
+            );
         }
 
         return historyTokens;


### PR DESCRIPTION
- saving spreadsheet name updates widget
- spreadsheet name validation or save failures restore original name
- improved failure messages for spreadsheet load and spreadsheet name save

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/923
- Spreadsheet name editing/save failure handling