### PR TITLE
SpreadsheetHistoryHash: formula without cell fix

### DIFF
--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -288,7 +288,7 @@ export default class SpreadsheetHistoryHash {
                 verified.push(cell.toString());
             }
 
-            if(!!formula){
+            if(cell && !!formula){
                 verified.push(SpreadsheetHistoryHash.CELL_FORMULA);
             }
 

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -1505,6 +1505,16 @@ test("replacements #2", () => {
     );
 });
 
+test("formula without cell", () => {
+    mergeAndCheck(
+        "/123abc/Untitled456",
+        {
+            "formula": true,
+        },
+        "/123abc/Untitled456"
+    );
+});
+
 function parseMergeAndPushHistoryFails(history) {
     test("parseMergeAndPush history: " + history + " fails", () => {
         expect(() => SpreadsheetHistoryHash.merge(history, {}, FUNCTION).toThrow("Expected object history got " + history));


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/940
- history hash formula without cell