### PR TITLE
Cypress integration App unused historyHashLabel restored

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -465,6 +465,11 @@ context(
                 .should('match', /.*\/Untitled/);
         });
 
+        function historyHashLabel() {
+            emptySpreadsheetWait();
+            hashAppend("/label/" + LABEL);
+        }
+
         function labelDialogCheck(title,
                                   labelText,
                                   labelHelperText,


### PR DESCRIPTION
- revert https://github.com/mP1/walkingkooka-spreadsheet-react/pull/945
- Cypress integration App unused historyHashLabel removed