### PR TITLE
SpreadsheetViewportWidget refresh label changes

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -519,6 +519,65 @@ context(
                 });
         });
 
+        it("Label mapping update, refreshes viewport", () => {
+            spreadsheetEmpty();
+            hash()
+                .should('match', /.*\/Untitled/);
+
+            cellClick("A1");
+
+            hash().should('match', /.*\/Untitled\/cell\/A1/)
+
+            formulaText()
+                .click()
+                .wait(FORMULA_TEXT_CLICK_WAIT)
+                .type("=11{enter}");
+
+            cellClick("B2");
+
+            hash().should('match', /.*\/Untitled\/cell\/B2/)
+
+            formulaText()
+                .click()
+                .wait(FORMULA_TEXT_CLICK_WAIT)
+                .type("=22{enter}")
+                .blur();
+
+            // create a new label
+            hashAppend("/label/MovingLabel");
+
+            labelMappingReferenceTextField()
+                .type("A1");
+
+            labelMappingLabelSaveButton()
+                .click();
+
+            labelMappingLabelCloseButton()
+                .click();
+
+            cellClick("C3");
+
+            hash().should('match', /.*\/Untitled\/cell\/C3/)
+
+            formulaText()
+                .click()
+                .wait(FORMULA_TEXT_CLICK_WAIT)
+                .type("=4*MovingLabel{enter}")
+                .blur();
+
+            cellFormattedTextCheck("C3", "44."); // 4 * 11
+
+            // update existing label
+            hashAppend("/label/MovingLabel");
+
+            labelMappingReferenceTextField()
+                .type("{selectall}B2{enter}");
+
+            labelMappingLabelSaveButton()
+                .click();
+
+            cellFormattedTextCheck("C3", "88."); // 4 * 22
+        });
 
         function labelDialogCheck(title,
                                   labelText,

--- a/src/spreadsheet/SpreadsheetApp.js
+++ b/src/spreadsheet/SpreadsheetApp.js
@@ -76,7 +76,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
             new ListenerCollection()
         );
 
-        this.labelMappingCrud = new SpreadsheetMessengerCrud(
+        this.spreadsheetLabelCrud = new SpreadsheetMessengerCrud(
             (method, label) => this.labelUrl(label),
             messenger,
             SpreadsheetLabelMapping.fromJson,
@@ -267,6 +267,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
         const {
             messenger,
             spreadsheetDeltaCrud,
+            spreadsheetLabelCrud,
             spreadsheetMetadataCrud,
             state,
         } = this;
@@ -289,7 +290,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
                 />
                 <SpreadsheetLabelWidget key="labelWidget"
                                         history={history}
-                                        messengerCrud={this.labelMappingCrud}
+                                        spreadsheetLabelCrud={this.spreadsheetLabelCrud}
                                         notificationShow={notificationShow}
                                         showError={showError}
                 />
@@ -322,6 +323,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
                                            ref={this.viewport}
                                            messenger={messenger}
                                            spreadsheetDeltaCrud={spreadsheetDeltaCrud}
+                                           spreadsheetLabelCrud={spreadsheetLabelCrud}
                                            spreadsheetMetadataCrud={spreadsheetMetadataCrud}
                                            showError={showError}
                 />

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -73,6 +73,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
         const props = this.props;
         this.onSpreadsheetDeltaRemover = props.spreadsheetDeltaCrud.addListener(this.onSpreadsheetDelta.bind(this));
+        this.onSpreadsheetLabelCrudRemover = props.spreadsheetLabelCrud.addListener(this.onSpreadsheetLabel.bind(this));
         this.onSpreadsheetMetadataRemover = props.spreadsheetMetadataCrud.addListener(this.onSpreadsheetMetadata.bind(this));
     }
 
@@ -93,6 +94,31 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
         this.setState(newState);
     }
 
+    /**
+     * If a label was saved o deleted refresh the viewport.
+     */
+    onSpreadsheetLabel(method, id, label) {
+        switch(method) {
+            case "DELETE":
+            case "POST":
+                const viewportTable = this.viewportTable.current;
+                if(viewportTable){
+                    this.viewportLoadCells(
+                        new SpreadsheetViewport(
+                            this.state.spreadsheetMetadata.getIgnoringDefaults(SpreadsheetMetadata.VIEWPORT_CELL),
+                            0,
+                            0,
+                            viewportTable.offsetWidth,
+                            viewportTable.offsetHeight,
+                        )
+                    );
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
     onSpreadsheetMetadata(method, id, metadata) {
         this.setState({
             spreadsheetMetadata: metadata,
@@ -104,6 +130,9 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
         this.onSpreadsheetDeltaRemover && this.onSpreadsheetDeltaRemover();
         delete this.onSpreadsheetDeltaRemover;
+
+        this.onSpreadsheetLabelCrudRemover && this.onSpreadsheetLabelCrudRemover();
+        delete this.onSpreadsheetLabelCrudRemover;
 
         this.onSpreadsheetMetadataRemover && this.onSpreadsheetMetadataRemover();
         delete this.onSpreadsheetMetadataRemover;
@@ -542,6 +571,7 @@ SpreadsheetViewportWidget.propTypes = {
     history: PropTypes.object.isRequired,
     messenger: PropTypes.instanceOf(SpreadsheetMessenger),
     spreadsheetDeltaCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
+    spreadsheetLabelCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     spreadsheetMetadataCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     showError: PropTypes.func.isRequired,
 }

--- a/src/spreadsheet/reference/SpreadsheetLabelWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelWidget.js
@@ -51,7 +51,7 @@ export default class SpreadsheetLabelWidget extends SpreadsheetHistoryAwareState
         if(open){
             if(null != label && !Equality.safeEquals(prevState.label, label)){
                 // load the mapping for the new $label, the old mapping is lost.
-                this.props.messengerCrud.get(
+                this.props.spreadsheetLabelCrud.get(
                     label,
                     {},
                     this.onLabelMappingLoadSuccess.bind(this),
@@ -222,7 +222,7 @@ export default class SpreadsheetLabelWidget extends SpreadsheetHistoryAwareState
      * ignoring the label text field.
      */
     onDeleteButtonClicked() {
-        this.props.messengerCrud.delete(
+        this.props.spreadsheetLabelCrud.delete(
             this.state.label,
             this.onLabelMappingDeleteSuccess.bind(this),
             this.props.showError
@@ -247,7 +247,7 @@ export default class SpreadsheetLabelWidget extends SpreadsheetHistoryAwareState
             if(newLabel){
                 const reference = this.parseReference(this.reference.current.value, newState);
                 if(reference){
-                    props.messengerCrud.post(
+                    props.spreadsheetLabelCrud.post(
                         oldLabel,
                         new SpreadsheetLabelMapping(newLabel, reference),
                         this.onLabelMappingSaveSuccess.bind(this),
@@ -298,7 +298,7 @@ export default class SpreadsheetLabelWidget extends SpreadsheetHistoryAwareState
 
 SpreadsheetLabelWidget.propTypes = {
     history: PropTypes.object.isRequired,
-    messengerCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
+    spreadsheetLabelCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     notificationShow: PropTypes.func.isRequired, // used to display notifications including errors and other messages
     showError: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
- SpreadsheetApp holds spreadsheetLabelCrud in a field.
- SpreadsheetLabelWidget.spreadsheetLabelCrud was this.props.messengerCrud.get

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/821
- Label update doesnt refresh viewport