### PR TITLE
ListenerCollection remover fix

### DIFF
--- a/src/event/ListenerCollection.js
+++ b/src/event/ListenerCollection.js
@@ -16,7 +16,10 @@ export default class ListenerCollection {
         listeners.push(listener);
 
         return () => {
-            listeners.splice(listeners.findIndex(listener), 1);
+            const index = listeners.indexOf(listener);
+            if(-1 !== index){
+                listeners.splice(index, 1);
+            }
         };
     }
 


### PR DESCRIPTION
- Previously using findIndex which of course invokes listener, replaced with indexOf
- Fixed incorrect invoking of listener function causing errors due to missing parameter values.