### PR TITLE
SpreadsheetViewportWidget cell click saves metadata

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -302,15 +302,13 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
         this.setState(newState);
 
         if(!Equality.safeEquals(metadata, previousMetadata)){
-            if(SpreadsheetViewportWidget.m > 0) {
-                this.props.spreadsheetMetadataCrud.post(
-                    metadata.getIgnoringDefaults(SpreadsheetMetadata.SPREADSHEET_ID),
-                    metadata,
-                    () => {
-                    },
-                    this.props.showError
-                );
-            }
+            this.props.spreadsheetMetadataCrud.post(
+                metadata.getIgnoringDefaults(SpreadsheetMetadata.SPREADSHEET_ID),
+                metadata,
+                () => {
+                },
+                this.props.showError
+            );
         }
 
         return historyTokens;


### PR DESCRIPTION
- removed debug if which caused posting of SpreadsheetMetadata to be skipped.