### PR TITLE
SpreadsheetHistoryHash instance shared

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -843,7 +843,11 @@ context(
 
             cellClick("C3");
 
+            renderWait(FORMULA_TEXT_CLICK_WAIT);
+
             hashAppend("/formula");
+
+            renderWait(FORMULA_TEXT_CLICK_WAIT);
 
             formulaText()
                 .should("have.focus");

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,56 @@
+import './index.css';
+import * as serviceWorker from './serviceWorker';
+import Preconditions from "./Preconditions.js";
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {HashRouter} from "react-router-dom";
-import './index.css';
 import SpreadsheetApp from './spreadsheet/SpreadsheetApp.js';
-import * as serviceWorker from './serviceWorker';
+import SpreadsheetHistoryHash from "./spreadsheet/history/SpreadsheetHistoryHash.js";
+import SpreadsheetNotificationWidget from "./spreadsheet/notification/SpreadsheetNotificationWidget.js";
+import SpreadsheetNotification from "./spreadsheet/notification/SpreadsheetNotification.js";
+
+const notificationWidget = new SpreadsheetNotificationWidget();
+const showError = function(message, error) {
+    notificationShow(SpreadsheetNotification.error(message));
+    console.error(message, error);
+}
+
+const notificationShow = function(notification) {
+    Preconditions.optionalInstance(notification, SpreadsheetNotification, "notification");
+    console.log("notificationShow ", notification);
+
+    notificationWidget.setState(
+        {
+            notification: notification
+        }
+    );
+}
+
+const location = window.location;
+const spreadsheetHistoryHash = new SpreadsheetHistoryHash(
+    () => {
+        const hash = location.hash;
+        return hash.startsWith("#") ? hash.substring(1) : "";
+    },
+    (hash) => {
+        const hashhash = hash ? "#" + hash : "";
+
+        if(location.hash !== hashhash){
+            location.hash = hashhash;
+        }
+    },
+    showError
+);
+window.addEventListener(
+    "hashchange",
+    spreadsheetHistoryHash.onHistoryChange.bind(spreadsheetHistoryHash),
+    false
+);
 
 ReactDOM.render(
     <React.StrictMode>
-        <HashRouter>
-            <SpreadsheetApp/>
-        </HashRouter>
+        <SpreadsheetApp history={spreadsheetHistoryHash}
+                        notificationShow={notificationShow}
+                        showError={showError}/>
     </React.StrictMode>,
     document.getElementById('root')
 );

--- a/src/spreadsheet/SpreadsheetApp.js
+++ b/src/spreadsheet/SpreadsheetApp.js
@@ -1,4 +1,3 @@
-import {withRouter} from "react-router";
 import './SpreadsheetApp.css';
 
 import {withStyles} from '@material-ui/core/styles';
@@ -25,7 +24,6 @@ import SpreadsheetNameWidget from "./SpreadsheetNameWidget.js";
 import SpreadsheetNavigateAutocompleteWidget from "./reference/SpreadsheetNavigateAutocompleteWidget.js";
 import SpreadsheetNavigateLinkWidget from "./reference/SpreadsheetNavigateLinkWidget.js";
 import SpreadsheetNotification from "./notification/SpreadsheetNotification.js";
-import SpreadsheetNotificationWidget from "./notification/SpreadsheetNotificationWidget.js";
 import SpreadsheetSettingsWidget from "./settings/SpreadsheetSettingsWidget.js";
 import SpreadsheetViewportWidget from "./SpreadsheetViewportWidget.js";
 import WindowResizer from "../widget/WindowResizer.js";
@@ -51,7 +49,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
     // init.............................................................................................................
 
     init() {
-        const showError = this.showError.bind(this);
+        const showError = this.props.showError;
 
         const messenger = new SpreadsheetMessenger(showError);
         messenger.setWebWorker(false); // TODO test webworker mode
@@ -178,7 +176,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
                         {},
                         () => {
                         },
-                        (message, error) => this.showError("Unable to load spreadsheet " + id, error)
+                        (message, error) => this.props.showError("Unable to load spreadsheet " + id, error)
                     );
                 }
 
@@ -238,7 +236,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
             "",
             () => {
             },
-            this.showError.bind(this)
+            this.props.showError
         );
     }
 
@@ -250,7 +248,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
             spreadsheetMetadata: metadata,
         });
 
-        this.notificationShow(SpreadsheetNotification.success("Spreadsheet metadata saved"));
+        this.props.notificationShow(SpreadsheetNotification.success("Spreadsheet metadata saved"));
     }
 
     // rendering........................................................................................................
@@ -261,7 +259,9 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
     render() {
         const {
             classes,
-            history
+            history,
+            notificationShow,
+            showError,
         } = this.props;
 
         const {
@@ -274,14 +274,8 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
 
         console.log("render", state);
 
-        const notificationShow = this.notificationShow.bind(this);
-        const showError = this.showError.bind(this);
-
         return (
             <WindowResizer dimensions={this.onWindowResized.bind(this)}>
-                <SpreadsheetNotificationWidget ref={this.notification}
-                                               key="notification"
-                />
                 <SpreadsheetNavigateAutocompleteWidget key="navigateAutocompleteWidget"
                                                        history={history}
                                                        getSimilarities={this.similaritiesGet.bind(this)}
@@ -347,23 +341,8 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
             url,
             parameters,
             response,
-            error || this.showError.bind(this),
+            error || this.props.showError,
         )
-    }
-
-    // Notifications....................................................................................................
-
-    notificationShow(notification) {
-        Preconditions.optionalInstance(notification, SpreadsheetNotification, "notification");
-
-        console.log("notificationShow ", notification);
-
-        const widget = this.notification.current;
-        widget && widget.setState(
-            {
-                notification: notification
-            }
-        );
     }
 
     // settings.........................................................................................................
@@ -429,11 +408,6 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
         });
     }
 
-    showError(message, error) {
-        this.notificationShow(SpreadsheetNotification.error(message));
-        console.error(message, error);
-    }
-
     // toString.........................................................................................................
 
     toString() {
@@ -441,4 +415,4 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
     }
 }
 
-export default withRouter(withStyles(useStyles)(SpreadsheetApp));
+export default withStyles(useStyles)(SpreadsheetApp);

--- a/src/spreadsheet/SpreadsheetFormulaWidget.js
+++ b/src/spreadsheet/SpreadsheetFormulaWidget.js
@@ -300,7 +300,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
 }
 
 SpreadsheetFormulaWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     spreadsheetDeltaCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     showError: PropTypes.func.isRequired,
 }

--- a/src/spreadsheet/SpreadsheetNameWidget.js
+++ b/src/spreadsheet/SpreadsheetNameWidget.js
@@ -70,7 +70,6 @@ export default class SpreadsheetNameWidget extends SpreadsheetHistoryAwareStateW
 
         const historyTokens = {};
         historyTokens[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = edit;
-        console.log("history tokens name edit: " + edit, historyTokens, "state", state, "history", this.props.history.location.pathname);
         return historyTokens;
     }
 
@@ -129,7 +128,7 @@ export default class SpreadsheetNameWidget extends SpreadsheetHistoryAwareStateW
 }
 
 SpreadsheetNameWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     spreadsheetMetadataCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud).isRequired,
     showError: PropTypes.func.isRequired,
 }

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -271,6 +271,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                     newState = {
                         cell: cellOrLabelNew,
                     };
+                    metadata = metadata.setOrRemove(SpreadsheetMetadata.SELECTION, cellOrLabelNew);
                 }
             }
 
@@ -720,7 +721,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
 SpreadsheetViewportWidget.propTypes = {
     dimensions: PropTypes.object,
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     messenger: PropTypes.instanceOf(SpreadsheetMessenger),
     spreadsheetDeltaCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     spreadsheetLabelCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),

--- a/src/spreadsheet/history/SpreadsheetHistoryAwareStateWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareStateWidget.js
@@ -19,12 +19,7 @@ export default class SpreadsheetHistoryAwareStateWidget extends SpreadsheetHisto
 
         this.state = Object.assign(
             this.initialStateFromProps(props),
-            this.stateFromHistoryTokens(
-                SpreadsheetHistoryHash.parse(
-                    props.history.location.pathname,
-                    this.showError.bind(this),
-                )
-            )
+            props.history.tokens()
         );
     }
 
@@ -77,5 +72,5 @@ export default class SpreadsheetHistoryAwareStateWidget extends SpreadsheetHisto
 }
 
 SpreadsheetHistoryAwareStateWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired
 }

--- a/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
@@ -18,28 +18,7 @@ export default class SpreadsheetHistoryAwareWidget extends React.Component {
     }
 
     componentDidMount() {
-        const history = this.props.history;
-        this.historyUnlisten = history.listen(
-            (location) => {
-                // before firing events, verify the history has is actually valid, if invalid push the fixed
-                const pathname = location.pathname;
-                const tokens = SpreadsheetHistoryHash.parse(
-                    pathname,
-                    this.showError.bind(this)
-                );
-
-                const merged = SpreadsheetHistoryHash.merge(
-                    tokens,
-                    {}
-                );
-                const updatedPathname = SpreadsheetHistoryHash.join(merged);
-                if(updatedPathname !== history.location.pathname){
-                    history.push(updatedPathname);
-                }
-
-                this.onHistoryChange(tokens);
-            }
-        );
+        this.historyUnlisten = this.props.history.addListener(this.onHistoryChange.bind(this));
     }
 
     componentWillUnmount() {
@@ -52,11 +31,7 @@ export default class SpreadsheetHistoryAwareWidget extends React.Component {
     }
 
     historyParseMergeAndPush(tokens) {
-        SpreadsheetHistoryHash.parseMergeAndPush(
-            this.props.history,
-            tokens,
-            this.showError.bind(this)
-        );
+        this.props.history.mergeAndPush(tokens);
     }
 
     showError(message, error) {
@@ -65,5 +40,5 @@ export default class SpreadsheetHistoryAwareWidget extends React.Component {
 }
 
 SpreadsheetHistoryAwareWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired
 }

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -1,7 +1,9 @@
+import ListenerCollection from "../../event/ListenerCollection.js";
 import Preconditions from "../../Preconditions.js";
 import spreadsheetCellReferenceOrLabelNameFromJson from "../reference/SpreadsheetCellReferenceOrLabelNameFromJson.js";
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
+import SpreadsheetSelection from "../reference/SpreadsheetSelection.js";
 
 function tokenize(pathname) {
     return pathname && pathname.startsWith("/") ?
@@ -58,42 +60,30 @@ export default class SpreadsheetHistoryHash {
     /**
      * Parsers the path extracting tokens returning an object with valid tokens. Invalid combination will be removed.
      */
-    static parse(pathname, errors) {
-        Preconditions.requireText(pathname, "pathname");
+    static parse(hash, errors) {
+        Preconditions.requireText(hash, "hash");
         Preconditions.requireFunction(errors, "errors");
 
-        const sourceTokens = tokenize(pathname);
+        const sourceTokens = tokenize(hash);
+        const spreadsheetId = sourceTokens.shift();
+        const tokens = {};
 
-        var valid = true;
+        if(spreadsheetId){
+            tokens[SpreadsheetHistoryHash.SPREADSHEET_ID] = spreadsheetId;
 
-        var spreadsheetId = sourceTokens.shift();
-        var spreadsheetName;
-        var nameEdit;
-        var cell;
-        var formula;
-        var label;
-        var navigate;
-        var settings;
-        var settingsSection;
-
-        if(null != spreadsheetId){
             try {
-                spreadsheetName = new SpreadsheetName(sourceTokens.shift());
-            } catch (ignore) {
-            }
+                tokens[SpreadsheetHistoryHash.SPREADSHEET_NAME] = new SpreadsheetName(sourceTokens.shift());
 
-            if(null != spreadsheetName){
+                const tokens2 = {};
+                var valid = true;
+                var cell = null;
 
                 while(sourceTokens.length > 0 && valid) {
                     const token = sourceTokens.shift();
 
                     switch(token) {
                         case SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT:
-                            if(cell){
-                                valid = false;
-                                break;
-                            }
-                            nameEdit = true;
+                            tokens2[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = true;
                             break;
                         case SpreadsheetHistoryHash.CELL:
                             if(sourceTokens.length === 0){
@@ -107,13 +97,14 @@ export default class SpreadsheetHistoryHash {
                                 errors("Cell: " + invalid.message);
                                 valid = false;
                             }
+                            tokens2[SpreadsheetHistoryHash.CELL] = cell;
                             break;
                         case SpreadsheetHistoryHash.CELL_FORMULA:
                             if(!cell){
                                 valid = false;
                                 break;
                             }
-                            formula = true;
+                            tokens2[SpreadsheetHistoryHash.CELL_FORMULA] = true;
                             break;
                         case SpreadsheetHistoryHash.LABEL:
                             if(sourceTokens.length === 0){
@@ -121,22 +112,24 @@ export default class SpreadsheetHistoryHash {
                                 break;
                             }
 
+                            var label = null;
                             try {
                                 label = SpreadsheetLabelName.parse(sourceTokens.shift());
                             } catch(invalid) {
                                 errors("Label: " + invalid.message);
                                 valid = false;
                             }
+                            tokens2[SpreadsheetHistoryHash.LABEL] = label;
                             break;
                         case SpreadsheetHistoryHash.NAVIGATE:
-                            navigate = true;
+                            tokens2[SpreadsheetHistoryHash.NAVIGATE] = true;
                             break;
                         case SpreadsheetHistoryHash.SETTINGS:
-                            settings = true;
+                            tokens2[SpreadsheetHistoryHash.SETTINGS] = true;
                             const possibleSection = sourceTokens.shift();
                             if(null != possibleSection){
                                 if(isSettingsToken(possibleSection)){
-                                    settingsSection = possibleSection;
+                                    tokens2[SpreadsheetHistoryHash.SETTINGS_SECTION] = possibleSection;
                                 }
                             }
                             valid = true;
@@ -146,56 +139,89 @@ export default class SpreadsheetHistoryHash {
                             break;
                     }
                 }
+
+                if(valid) {
+                    Object.assign(tokens, tokens2);
+                }
+            } catch(ignore) {
             }
         }
 
-        const destTokens = {};
+        return SpreadsheetHistoryHash.validate(tokens);
+    }
+
+    /**
+     * Verifies the given tokens are valid, for example formula cannot be set if cell if absent.
+     */
+    static validate(tokens) {
+        var spreadsheetId = tokens[SpreadsheetHistoryHash.SPREADSHEET_ID];
+        var spreadsheetName = tokens[SpreadsheetHistoryHash.SPREADSHEET_NAME];
+        var nameEdit = tokens[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT];
+        var cell = tokens[SpreadsheetHistoryHash.CELL];
+        var formula = tokens[SpreadsheetHistoryHash.CELL_FORMULA];
+        var label = tokens[SpreadsheetHistoryHash.LABEL];
+        var navigate = tokens[SpreadsheetHistoryHash.NAVIGATE];
+        var settings = tokens[SpreadsheetHistoryHash.SETTINGS];
+        var settingsSection = tokens[SpreadsheetHistoryHash.SETTINGS_SECTION];
+
+        const verified = {};
 
         if(spreadsheetId){
-            destTokens[SpreadsheetHistoryHash.SPREADSHEET_ID] = spreadsheetId;
+            verified[SpreadsheetHistoryHash.SPREADSHEET_ID] = spreadsheetId;
 
             if(spreadsheetName){
-                destTokens[SpreadsheetHistoryHash.SPREADSHEET_NAME] = spreadsheetName;
+                verified[SpreadsheetHistoryHash.SPREADSHEET_NAME] = spreadsheetName;
+                if(nameEdit && (cell || label || navigate || settings)){
+                    nameEdit = false;
+                    cell = false;
+                    label = false;
+                    navigate = false;
+                }
+                if(nameEdit){
+                    cell = false;
+                    label = false;
+                    navigate = false;
+                }
+                if(cell || label || navigate || settings){
+                    nameEdit = false;
+                }
+                if(formula && !cell){
+                    formula = false;
+                }
+                if(nameEdit){
+                    verified[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = nameEdit;
+                }
+                if(cell instanceof SpreadsheetSelection){
+                    verified[SpreadsheetHistoryHash.CELL] = cell;
+                    if(formula){
+                        verified[SpreadsheetHistoryHash.CELL_FORMULA] = formula;
+                    }
+                }
+                if(label instanceof SpreadsheetLabelName){
+                    verified[SpreadsheetHistoryHash.LABEL] = label;
+                }
+                if(navigate){
+                    verified[SpreadsheetHistoryHash.NAVIGATE] = navigate;
+                }
+                if(settings){
+                    verified[SpreadsheetHistoryHash.SETTINGS] = settings;
 
-                if(valid){
-                    if(cell || label || navigate || settings) {
-                        nameEdit = false;
-                    }
-                    if(nameEdit){
-                        destTokens[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = nameEdit;
-                    }
-                    if(cell){
-                        destTokens[SpreadsheetHistoryHash.CELL] = cell;
-                        if(formula){
-                            destTokens[SpreadsheetHistoryHash.CELL_FORMULA] = formula;
-                        }
-                    }
-                    if(label){
-                        destTokens[SpreadsheetHistoryHash.LABEL] = label;
-                    }
-                    if(navigate){
-                        destTokens[SpreadsheetHistoryHash.NAVIGATE] = navigate;
-                    }
-                    if(settings){
-                        destTokens[SpreadsheetHistoryHash.SETTINGS] = settings;
-
-                        if(settingsSection){
-                            destTokens[SpreadsheetHistoryHash.SETTINGS_SECTION] = settingsSection;
-                        }
+                    if(settingsSection){
+                        verified[SpreadsheetHistoryHash.SETTINGS_SECTION] = settingsSection;
                     }
                 }
             }
         }
 
-        return destTokens;
+        return verified;
     }
 
     /**
-     * Merges the current tokens with the replacements giving the merged result as another object.
+     * Merges the two history has objects, using the delta to update and return a new object of hashes.
      */
-    static merge(current, replacements) {
+    static merge(current, delta) {
         Preconditions.requireObject(current, "current");
-        Preconditions.requireObject(replacements, "replacements");
+        Preconditions.requireObject(delta, "delta");
 
         // get the current
         var spreadsheetId = current[SpreadsheetHistoryHash.SPREADSHEET_ID];
@@ -209,16 +235,16 @@ export default class SpreadsheetHistoryHash {
         var settingsSection = current[SpreadsheetHistoryHash.SETTINGS_SECTION];
 
         // try replacing...
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_ID)){
-            spreadsheetId = replacements[SpreadsheetHistoryHash.SPREADSHEET_ID];
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_ID)){
+            spreadsheetId = delta[SpreadsheetHistoryHash.SPREADSHEET_ID];
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_NAME)){
-            spreadsheetName = replacements[SpreadsheetHistoryHash.SPREADSHEET_NAME];
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_NAME)){
+            spreadsheetName = delta[SpreadsheetHistoryHash.SPREADSHEET_NAME];
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT)){
-            nameEdit = !!replacements[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT];
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT)){
+            nameEdit = !!delta[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT];
             if(nameEdit){
                 cell = null;
                 formula = null;
@@ -228,55 +254,55 @@ export default class SpreadsheetHistoryHash {
             }
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.CELL)) {
-            cell = replacements[SpreadsheetHistoryHash.CELL];
-            if(cell) {
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.CELL)){
+            cell = delta[SpreadsheetHistoryHash.CELL];
+            if(cell){
                 nameEdit = false;
             }
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.CELL_FORMULA)){
-            formula = replacements[SpreadsheetHistoryHash.CELL_FORMULA];
-            if(formula) {
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.CELL_FORMULA)){
+            formula = delta[SpreadsheetHistoryHash.CELL_FORMULA];
+            if(formula){
                 nameEdit = false;
             }
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.LABEL)){
-            label = replacements[SpreadsheetHistoryHash.LABEL];
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.LABEL)){
+            label = delta[SpreadsheetHistoryHash.LABEL];
 
-            if(label) {
+            if(label){
                 nameEdit = false;
             }
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.NAVIGATE)){
-            navigate = replacements[SpreadsheetHistoryHash.NAVIGATE];
-            if(navigate) {
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.NAVIGATE)){
+            navigate = delta[SpreadsheetHistoryHash.NAVIGATE];
+            if(navigate){
                 nameEdit = false;
             }
         }
 
-        if(replacements.hasOwnProperty(SpreadsheetHistoryHash.SETTINGS)){
-            settings = replacements[SpreadsheetHistoryHash.SETTINGS];
-            settingsSection = replacements[SpreadsheetHistoryHash.SETTINGS_SECTION];
+        if(delta.hasOwnProperty(SpreadsheetHistoryHash.SETTINGS)){
+            settings = delta[SpreadsheetHistoryHash.SETTINGS];
+            settingsSection = delta[SpreadsheetHistoryHash.SETTINGS_SECTION];
             if(settingsSection && !isSettingsToken(settingsSection)){
                 settingsSection = null;
             }
         }
 
-        // create the resulting verified history token pathname
-        const verified = [];
+        const merged = {};
         let valid = false;
 
         if(null != spreadsheetId){
-            verified.push(spreadsheetId);
+            merged[SpreadsheetHistoryHash.SPREADSHEET_ID] = spreadsheetId;
+
             if(null != spreadsheetName){
-                verified.push(spreadsheetName);
+                merged[SpreadsheetHistoryHash.SPREADSHEET_NAME] = spreadsheetName;
 
                 valid = true;
-                if(nameEdit) {
-                    if(cell || label || navigate || settings) {
+                if(nameEdit){
+                    if(cell || label || navigate || settings){
                         valid = false;
                     }
                 }
@@ -285,86 +311,191 @@ export default class SpreadsheetHistoryHash {
 
         if(valid){
             if(nameEdit){
-                verified.push(SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT);
+                merged[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT] = nameEdit;
             }
 
             if(cell){
-                verified.push(SpreadsheetHistoryHash.CELL);
-                verified.push(cell.toString());
+                merged[SpreadsheetHistoryHash.CELL] = cell;
             }
 
             if(cell && !!formula){
-                verified.push(SpreadsheetHistoryHash.CELL_FORMULA);
+                merged[SpreadsheetHistoryHash.CELL_FORMULA] = formula;
             }
 
             if(label){
-                verified.push(SpreadsheetHistoryHash.LABEL);
-                verified.push(label.toString());
+                merged[SpreadsheetHistoryHash.LABEL] = label;
             }
 
             if(navigate){
-                verified.push(SpreadsheetHistoryHash.NAVIGATE);
+                merged[SpreadsheetHistoryHash.NAVIGATE] = navigate;
             }
 
             if(!!settings){
-                verified.push(SpreadsheetHistoryHash.SETTINGS);
+                merged[SpreadsheetHistoryHash.SETTINGS] = settings;
 
                 if(settingsSection){
-                    verified.push(settingsSection);
+                    merged[SpreadsheetHistoryHash.SETTINGS_SECTION] = settingsSection;
                 }
             }
         }
 
-        return verified;
+        return merged;
     }
 
     /**
-     * Parses the current history hash, merges the replacements and pushes the new hash.
+     * Accepts some history tokens, verifies the combinations are valid and returns the hash without the leading hash-sign.
      */
-    static parseMergeAndPush(history, replacements, showErrors) {
-        Preconditions.requireNonNull(history, "history");
-        Preconditions.requireObject(replacements, "replacements");
-        Preconditions.requireFunction(showErrors, "showErrors");
+    static stringify(tokens) {
+        var spreadsheetId = tokens[SpreadsheetHistoryHash.SPREADSHEET_ID];
+        var spreadsheetName = tokens[SpreadsheetHistoryHash.SPREADSHEET_NAME];
+        var nameEdit = tokens[SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT];
+        var cell = tokens[SpreadsheetHistoryHash.CELL];
+        var formula = tokens[SpreadsheetHistoryHash.CELL_FORMULA];
+        var label = tokens[SpreadsheetHistoryHash.LABEL];
+        var navigate = tokens[SpreadsheetHistoryHash.NAVIGATE];
+        var settings = tokens[SpreadsheetHistoryHash.SETTINGS];
+        var settingsSection = tokens[SpreadsheetHistoryHash.SETTINGS_SECTION];
 
-        // empty replacements is a noop.
-        if(Object.keys(replacements).length > 0){
-            const currentPathname = history.location.pathname;
-            const tokens = SpreadsheetHistoryHash.parse(currentPathname, showErrors);
+        let hash = "";
+        let valid = false;
 
-            const merged = SpreadsheetHistoryHash.merge(
-                tokens,
-                replacements
-            );
-            const updatedPathname = SpreadsheetHistoryHash.join(merged);
-            if(currentPathname !== updatedPathname){
-                console.log("parseMergeAndPush history changed from \"" + currentPathname + "\" to \"" + updatedPathname + "\" ", replacements);
-                history.push(updatedPathname);
-            }else {
-                console.log("parseMergeAndPush history unchanged \"" + currentPathname + "\"");
+        if(null != spreadsheetId){
+            hash = "/" + spreadsheetId;
+
+            if(null != spreadsheetName){
+                hash = hash + "/" + spreadsheetName;
+
+                valid = true;
+                if(nameEdit){
+                    if(cell || label || navigate || settings){
+                        valid = false;
+                    }
+                }
             }
         }
+
+        if(valid){
+            if(nameEdit){
+                hash = hash + "/" + SpreadsheetHistoryHash.SPREADSHEET_NAME_EDIT;
+                cell = null;
+                formula = null;
+                label = null;
+                navigate = null;
+            }
+
+            if(cell){
+                hash = hash + "/" + SpreadsheetHistoryHash.CELL + "/" + cell;
+            }
+
+            if(cell && !!formula){
+                hash = hash + "/" + SpreadsheetHistoryHash.CELL_FORMULA;
+            }
+
+            if(label){
+                hash = hash + "/" + SpreadsheetHistoryHash.LABEL + "/" + label;
+            }
+
+            if(navigate){
+                hash = hash + "/" + SpreadsheetHistoryHash.NAVIGATE;
+            }
+
+            if(!!settings){
+                hash = hash + "/" + SpreadsheetHistoryHash.SETTINGS;
+
+                if(settingsSection){
+                    hash = hash + "/" + settingsSection;
+                }
+            }
+        }
+
+        return hash;
     }
 
-    static join(tokens) {
-        Preconditions.requireArray(tokens, "tokens");
+    constructor(hash, setHash, showError) {
+        Preconditions.requireFunction(hash, "hash");
+        Preconditions.requireFunction(setHash, "setHash");
+        Preconditions.requireFunction(showError, "showError");
 
-        var s = "";
-        for(var i = 0; i < tokens.length; i++) {
-            const token = tokens[i];
+        this.hash = hash;
+        this.setHash = setHash;
+        this.showError = showError;
 
-            // stop joining if a undefined/null token is found.
-            if(!token && token !== ""){
+        this.listeners = new ListenerCollection();
+        this.hashCounter = 0;
+        this.currentTokens = SpreadsheetHistoryHash.parse(
+            hash(),
+            this.showError
+        );
+    }
+
+    onHistoryChange(e) {
+        const hash = this.hash();
+        const tokens = SpreadsheetHistoryHash.parse(
+            hash,
+            this.showError
+        );
+
+        const merged = SpreadsheetHistoryHash.merge(
+            tokens,
+            {}
+        );
+        this.push(merged);
+
+        this.currentTokens = merged;
+
+        const hashCounter = this.hashCounter;
+        for(const listener of this.listeners.listeners.slice()) {
+            if(this.hashCounter !== hashCounter){
                 break;
             }
-            s = s + "/" + token;
+            listener(Object.assign({}, merged));
         }
-
-        return s === "" ? "/" : s;
     }
 
+    tokens() {
+        let currentTokens = this.currentTokens;
+        if(null == currentTokens){
+            const hash = this.hash();
+            const tokens = SpreadsheetHistoryHash.parse(
+                hash,
+                this.showError
+            );
+            this.push(tokens);
+            this.currentTokens = tokens;
+        }
+        return Object.assign({}, this.currentTokens);
+    }
 
-    constructor(history) {
-        Preconditions.requireObject(history, "history");
-        this.history = history;
+    /**
+     * Adds a new history hash listener, returning a function which when invoked will remove the added listener.
+     */
+    addListener(listener) {
+        return this.listeners.add(listener);
+    }
+
+    /**
+     * Accepts some new history tokens and combines them with the current. This may result in some feature being cancelled,
+     * eg editing the spreadsheet name turns off cell, label, navigate and settings.
+     */
+    mergeAndPush(tokens) {
+        return this.push(SpreadsheetHistoryHash.merge(this.tokens(), tokens));
+    }
+
+    push(tokens) {
+        const validated = SpreadsheetHistoryHash.validate(tokens);
+        const tokensHash = SpreadsheetHistoryHash.stringify(validated);
+        const hash = this.hash();
+        if(tokensHash !== hash){
+            this.hashCounter++;
+            this.currentTokens = null;
+            this.setHash(tokensHash);
+        }
+        return validated;
+    }
+
+    mergeAndStringify(tokens) {
+        return SpreadsheetHistoryHash.stringify(
+            SpreadsheetHistoryHash.merge(this.tokens(), tokens)
+        );
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetLabelWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelWidget.js
@@ -297,7 +297,7 @@ export default class SpreadsheetLabelWidget extends SpreadsheetHistoryAwareState
 }
 
 SpreadsheetLabelWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     spreadsheetLabelCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
     notificationShow: PropTypes.func.isRequired, // used to display notifications including errors and other messages
     showError: PropTypes.func.isRequired,

--- a/src/spreadsheet/reference/SpreadsheetNavigateAutocompleteWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetNavigateAutocompleteWidget.js
@@ -263,7 +263,7 @@ export default class SpreadsheetNavigateAutocompleteWidget extends SpreadsheetHi
 }
 
 SpreadsheetNavigateAutocompleteWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     getSimilarities: PropTypes.func.isRequired, // performs a search to find similarities to the query text field.
     notificationShow: PropTypes.func.isRequired, // used to display notifications including errors and other messages
     showError: PropTypes.func.isRequired, // used mostly to display failures around getSimilarities

--- a/src/spreadsheet/reference/SpreadsheetNavigateLinkWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetNavigateLinkWidget.js
@@ -24,11 +24,10 @@ export default class SpreadsheetNavigateLinkWidget extends SpreadsheetHistoryAwa
      * Recreate the target of the link.
      */
     stateFromHistoryTokens(tokens) {
-        const navigate = {};
-        navigate[SpreadsheetHistoryHash.NAVIGATE] = true;
+        tokens[SpreadsheetHistoryHash.NAVIGATE] = true;
 
         return {
-            target: '#' + SpreadsheetHistoryHash.join(SpreadsheetHistoryHash.merge(tokens, navigate)),
+            target: '#' + this.props.history.mergeAndStringify(tokens),
             cell: tokens[SpreadsheetHistoryHash.CELL],
         };
     }
@@ -56,6 +55,6 @@ export default class SpreadsheetNavigateLinkWidget extends SpreadsheetHistoryAwa
 }
 
 SpreadsheetNavigateLinkWidget.propTypes = {
-    history: PropTypes.object.isRequired,
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     showError: PropTypes.func.isRequired,
 }

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -1395,7 +1395,7 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
 }
 
 SpreadsheetSettingsWidget.propTypes = {
-    history: PropTypes.object.isRequired, // history will provide open
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     spreadsheetMetadataCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud).isRequired,
     notificationShow: PropTypes.func.isRequired,
     showError: PropTypes.func.isRequired,


### PR DESCRIPTION
- removes usage of HashRouter replaced with history object usage.
- Replaces previous static method calls w/ SpreadsheetHistoryHash instance methods.
- Moved creation of SpreadsheetNotificationWidget out of SpreadsheetApp.