### PR TITLE
Viewport cell focus fix

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -352,7 +352,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
     }
 
     giveFocus(cellReference) {
-        const cellElement = document.getElementById("cell-" + cellReference);
+        const cellElement = document.getElementById(cellReference.viewportId());
         if(cellElement){
             cellElement.focus();
         }


### PR DESCRIPTION
- Was using incorrect id, now using SpreadsheetCellReference.viewportId()

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1071
- Navigating around viewport using cursor keys unreliable