### PR TITLE
SpreadsheetHistoryHash column & row support

### DIFF
--- a/src/spreadsheet/SpreadsheetFormulaWidget.js
+++ b/src/spreadsheet/SpreadsheetFormulaWidget.js
@@ -56,7 +56,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
         const state = this.state || {};
 
         // if a cellOrLabel is present the formula text should also be editable.
-        const cellOrLabel = historyTokens[SpreadsheetHistoryHash.CELL];
+        const cellOrLabel = historyTokens[SpreadsheetHistoryHash.SELECTION];
         const formula = historyTokens[SpreadsheetHistoryHash.CELL_FORMULA];
         const edit = !!cellOrLabel;
         const giveFocus = edit && formula && !state.focused && !state.giveFocus;
@@ -84,7 +84,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
         console.log("historyTokensFromState formula cell " + prevState.cellOrLabel + " to " + cellOrLabel + " state", state);
 
         const historyTokens = {};
-        historyTokens[SpreadsheetHistoryHash.CELL] = cellOrLabel;
+        historyTokens[SpreadsheetHistoryHash.SELECTION] = cellOrLabel;
         historyTokens[SpreadsheetHistoryHash.CELL_FORMULA] = focused | giveFocus;
 
         // if not formula editing, disable textField

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -140,7 +140,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
     stateFromHistoryTokens(tokens) {
         return {
-            cellOrLabel: tokens[SpreadsheetHistoryHash.CELL],
+            selection: tokens[SpreadsheetHistoryHash.SELECTION],
             formula: tokens[SpreadsheetHistoryHash.CELL_FORMULA],
         };
     }
@@ -176,8 +176,8 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
             const width = viewportTable.offsetWidth;
             const height = viewportTable.offsetHeight;
 
-            const cellOrLabelOld = prevState.cellOrLabel;
-            const cellOrLabelNew = state.cellOrLabel;
+            const selectionOld = prevState.selection;
+            const selectionNew = state.selection;
 
             const cellNew = state.cell;
             const cellOld = prevState.cell;
@@ -218,7 +218,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                         break;
                     }
 
-                    if(viewportRange && cellNew && !cellNew.equals(cellOld) && !viewportRange.test(cellNew)){
+                    if(viewportRange && cellNew instanceof SpreadsheetCellReference && !cellNew.equals(cellOld) && !viewportRange.test(cellNew)){
                         console.log("New cell " + cellNew + " outside" + viewportRange + " scroll to");
 
                         this.viewportLoadCells(
@@ -235,18 +235,18 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                 break;
             }
 
-            if(!Equality.safeEquals(cellOrLabelOld, cellOrLabelNew)){
-                if(cellOrLabelNew instanceof SpreadsheetLabelName){
-                    this.resolveLabelToCell(cellOrLabelNew); // eventually updates state.cell
+            if(!Equality.safeEquals(selectionOld, selectionNew)){
+                if(selectionNew instanceof SpreadsheetLabelName){
+                    this.resolveLabelToCell(selectionNew); // eventually updates state.cell
                 }else {
                     newState = {
-                        cell: cellOrLabelNew,
+                        cell: selectionNew,
                     };
-                    metadata = metadata.setOrRemove(SpreadsheetMetadata.SELECTION, cellOrLabelNew);
+                    metadata = metadata.setOrRemove(SpreadsheetMetadata.SELECTION, selectionNew);
                 }
             }
 
-            historyTokens[SpreadsheetHistoryHash.CELL] = cellOrLabelNew;
+            historyTokens[SpreadsheetHistoryHash.SELECTION] = selectionNew;
             if(state.focused){
                 historyTokens[SpreadsheetHistoryHash.CELL_FORMULA] = null;
             }
@@ -294,13 +294,13 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
         const success = (cell) => this.setState({
             cell: cell,
-            cellOrLabel: label,
+            selection: label,
             spreadsheetMetadata: this.state.spreadsheetMetadata.set(SpreadsheetMetadata.SELECTION, cell),
         });
         const failure = (message, error) => {
             this.setState({
                 cell: null,
-                cellOrLabel: null,
+                selection: null,
             });
             props.showError(message, error);
         }
@@ -646,7 +646,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
         this.setState({
             cell: cellReference,
-            cellOrLabel: cellReference,
+            selection: cellReference,
             focused: false,
             spreadsheetMetadata: this.state.spreadsheetMetadata.set(SpreadsheetMetadata.SELECTION, cellReference),
         });
@@ -661,7 +661,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
     blurFormulaTextBox() {
         const tokens = {}
-        tokens[SpreadsheetHistoryHash.CELL] = null;
+        tokens[SpreadsheetHistoryHash.SELECTION] = null;
         tokens[SpreadsheetHistoryHash.CELL_FORMULA] = false;
 
         this.historyParseMergeAndPush(tokens);

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -1,12 +1,16 @@
 import CharSequences from "../../CharSequences.js";
 import SpreadsheetCellReference from "../reference/SpreadsheetCellReference.js";
+import SpreadsheetColumnReference from "../reference/SpreadsheetColumnReference.js";
 import SpreadsheetHistoryHash from "./SpreadsheetHistoryHash.js";
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
+import SpreadsheetRowReference from "../reference/SpreadsheetRowReference.js";
 
 const ID = "spreadsheet-id-123";
 const SPREADSHEET_NAME = new SpreadsheetName("spreadsheet-name-456");
 const CELL = SpreadsheetCellReference.parse("A1");
+const COLUMN = SpreadsheetColumnReference.parse("B");
+const ROW = SpreadsheetRowReference.parse("2");
 const LABEL = SpreadsheetLabelName.parse("Label123");
 
 // validate................................................................................................................
@@ -45,7 +49,7 @@ validateTest(
     {
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
     }
 );
 
@@ -54,7 +58,7 @@ validateTest(
     {
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": LABEL,
+        "selection": LABEL,
     }
 );
 
@@ -64,7 +68,7 @@ validateTest(
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
         "name": true,
-        "cell": CELL,
+        "selection": CELL,
     },
     {
         "spreadsheet-id": ID,
@@ -105,7 +109,7 @@ validateTest(
     {
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
     }
 );
 
@@ -114,7 +118,7 @@ validateTest(
     {
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": "!invalid",
+        "selection": "!invalid",
     },
     {
         "spreadsheet-id": ID,
@@ -127,7 +131,7 @@ validateTest(
     {
         "spreadsheet-id": ID,
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": LABEL,
+        "selection": LABEL,
     }
 );
 
@@ -259,7 +263,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
     }
 );
 
@@ -268,7 +272,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
         "formula": true,
     }
 );
@@ -278,7 +282,17 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": LABEL,
+        "selection": LABEL,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/Label123/formula",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": LABEL,
+        "formula": true,
     }
 );
 
@@ -321,7 +335,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("A2"),
+        "selection": SpreadsheetCellReference.parse("A2"),
         "label": LABEL,
     }
 );
@@ -331,7 +345,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("A2"),
+        "selection": SpreadsheetCellReference.parse("A2"),
         "formula": true,
         "label": LABEL,
     }
@@ -376,7 +390,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
         "select": true,
     }
 );
@@ -386,7 +400,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
         "formula": true,
         "select": true,
     }
@@ -397,7 +411,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
         "formula": true,
         "select": true,
         "settings": true,
@@ -410,6 +424,60 @@ parseAndStringifyTest(
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
         "label": LABEL,
+        "select": true,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/B",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": COLUMN,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/B/formula",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/B/select",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": COLUMN,
+        "select": true,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": ROW,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2/formula",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2/select",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": ROW,
         "select": true,
     }
 );
@@ -576,7 +644,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
     }
@@ -587,7 +655,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
     }
@@ -598,7 +666,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
         "settings-section": "metadata",
@@ -610,7 +678,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
         "settings-section": "text",
@@ -622,7 +690,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
         "settings-section": "number",
@@ -634,7 +702,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
         "settings-section": "date-time",
@@ -646,7 +714,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": SpreadsheetCellReference.parse("B2"),
+        "selection": SpreadsheetCellReference.parse("B2"),
         "formula": true,
         "settings": true,
         "settings-section": "style",
@@ -668,7 +736,7 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "cell": CELL,
+        "selection": CELL,
         "formula": true,
         "settings": true,
         "settings-section": SpreadsheetHistoryHash.SETTINGS_METADATA,
@@ -837,7 +905,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/name/!invalid",
         {
-            "cell": SpreadsheetCellReference.parse("A1")
+            "selection": SpreadsheetCellReference.parse("A1")
         },
         "/123abc/Untitled456/cell/A1"
     );
@@ -845,7 +913,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/name",
         {
-            "cell": null,
+            "selection": null,
         },
         "/123abc/Untitled456/name"
     );
@@ -853,7 +921,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/name",
         {
-            "cell": SpreadsheetCellReference.parse("A1"),
+            "selection": SpreadsheetCellReference.parse("A1"),
             "formula": true,
         },
         "/123abc/Untitled456/cell/A1/formula"
@@ -930,7 +998,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/cell",
         {
-            "cell": SpreadsheetCellReference.parse("A1"),
+            "selection": SpreadsheetCellReference.parse("A1"),
         },
         "/123abc/Untitled456/cell/A1"
     );
@@ -944,7 +1012,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/cell/A1",
         {
-            "cell": SpreadsheetCellReference.parse("B2"),
+            "selection": SpreadsheetCellReference.parse("B2"),
         },
         "/123abc/Untitled456/cell/B2"
     );
@@ -952,7 +1020,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/cell/A1/formula",
         {
-            "cell": SpreadsheetCellReference.parse("B2"),
+            "selection": SpreadsheetCellReference.parse("B2"),
         },
         "/123abc/Untitled456/cell/B2/formula"
     );
@@ -976,7 +1044,7 @@ mergeUpdatesFails([]);
     mergeTest(
         "/123abc/Untitled456/cell/A1",
         {
-            "cell": null,
+            "selection": null,
         },
         "/123abc/Untitled456"
     );
@@ -1397,7 +1465,7 @@ mergeUpdatesFails([]);
         {
             "spreadsheet-id": "456def",
             "spreadsheet-name": "new-spreadsheet-name-456",
-            "cell": SpreadsheetCellReference.parse("B2"),
+            "selection": SpreadsheetCellReference.parse("B2"),
             "formula": true,
             "settings": true,
         },
@@ -1409,7 +1477,7 @@ mergeUpdatesFails([]);
         {
             "spreadsheet-id": "456def",
             "spreadsheet-name": "new-spreadsheet-name-456",
-            "cell": SpreadsheetCellReference.parse("B2"),
+            "selection": SpreadsheetCellReference.parse("B2"),
             "formula": true,
             "settings": false,
         },

--- a/src/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.js
@@ -9,4 +9,9 @@ export default class SpreadsheetCellReferenceOrLabelName extends SpreadsheetExpr
     viewport(xOffset, yOffset, width, height) {
         return new SpreadsheetViewport(this, xOffset, yOffset, width, height);
     }
+
+    toSelectionHashToken() {
+        // avoid referencing constant to avoid runtime TypeErrors.
+        return /*SpreadsheetHistoryHash.CELL*/ "cell/" + this;
+    }
 }

--- a/src/spreadsheet/reference/SpreadsheetColumnReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReference.js
@@ -5,6 +5,7 @@ import SpreadsheetColumnOrRowReference from "./SpreadsheetColumnOrRowReference";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import SystemObject from "../../SystemObject.js";
+import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 
 const A = 65;
 const TYPE_NAME = "spreadsheet-column-reference";
@@ -75,6 +76,10 @@ export default class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRe
 
     typeName() {
         return TYPE_NAME;
+    }
+
+    toSelectionHashToken() {
+        return SpreadsheetHistoryHash.COLUMN + "/" + this;
     }
 
     toString() {

--- a/src/spreadsheet/reference/SpreadsheetRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReference.js
@@ -6,6 +6,7 @@ import SpreadsheetColumnOrRowReference from "./SpreadsheetColumnOrRowReference";
 import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadObject from "../../SystemObject.js";
+import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 
 const TYPE_NAME = "spreadsheet-row-reference";
 
@@ -74,6 +75,10 @@ export default class SpreadsheetRowReference extends SpreadsheetColumnOrRowRefer
     
     viewportId() {
         return "viewport-row-" + this.toString().toUpperCase();
+    }
+
+    toSelectionHashToken() {
+        return SpreadsheetHistoryHash.ROW + "/" + this;
     }
 
     typeName() {

--- a/src/spreadsheet/reference/SpreadsheetSelectAutocompleteWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetSelectAutocompleteWidget.js
@@ -238,7 +238,7 @@ export default class SpreadsheetSelectAutocompleteWidget extends SpreadsheetHist
 
         const historyTokens = {};
 
-        historyTokens[SpreadsheetHistoryHash.CELL] = gotoCellOrLabel;
+        historyTokens[SpreadsheetHistoryHash.SELECTION] = gotoCellOrLabel;
         historyTokens[SpreadsheetHistoryHash.CELL_FORMULA] = false;
         historyTokens[SpreadsheetHistoryHash.LABEL] = label;
         historyTokens[SpreadsheetHistoryHash.SELECT] = null; // close the navigate modal

--- a/src/spreadsheet/reference/SpreadsheetSelectLinkWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetSelectLinkWidget.js
@@ -28,7 +28,7 @@ export default class SpreadsheetSelectLinkWidget extends SpreadsheetHistoryAware
 
         return {
             target: '#' + this.props.history.mergeAndStringify(tokens),
-            cell: tokens[SpreadsheetHistoryHash.CELL],
+            cell: tokens[SpreadsheetHistoryHash.SELECTION],
         };
     }
 

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -16,4 +16,8 @@ export default class SpreadsheetSelection extends SystemObject {
     testRow(rowReference) {
         throw new Error("Not yet implemented");
     }
+
+    toSelectionHashToken() {
+        throw new Error("Not yet implemented");
+    }
 }


### PR DESCRIPTION
- Entering column/$column and row/$row into history hash selects column or row but no functionality is available.
- TODO Select modal widget support for entering column or rows.
- TODO Cursor key support for navigating around column and rows.