### PR TITLE
History hash column range support

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -1223,6 +1223,22 @@ context(
                 .should("have.css", "background-color", SELECTED_COLOR);
         });
 
+        // column range...................................................................................................
+
+        it("column range history hash", () => {
+            spreadsheetEmpty();
+
+            hashAppend("/column/B:C");
+
+            hash()
+                .should('match', /.*\/.*\/column\/B:C/);
+
+            column("B")
+                .should("have.css", "background-color", SELECTED_COLOR);
+            column("C")
+                .should("have.css", "background-color", SELECTED_COLOR);
+        });
+
         // select.....................................................................................................
 
         it("Select using hash initial appearance", () => {

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -3,10 +3,18 @@ import Preconditions from "../../Preconditions.js";
 import SpreadsheetCellReferenceOrLabelName from "../reference/SpreadsheetCellReferenceOrLabelName.js";
 import spreadsheetCellReferenceOrLabelNameParse from "../reference/SpreadsheetCellReferenceOrLabelNameParse.js";
 import SpreadsheetColumnReference from "../reference/SpreadsheetColumnReference.js";
+import SpreadsheetColumnReferenceRange from "../reference/SpreadsheetColumnReferenceRange.js";
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
 import SpreadsheetRowReference from "../reference/SpreadsheetRowReference.js";
 import SpreadsheetSelection from "../reference/SpreadsheetSelection.js";
+
+function columnOrColumnRangeParse(text) {
+    const colon = text.indexOf(":");
+    return -1 === colon ?
+        SpreadsheetColumnReference.parse(text) :
+        SpreadsheetColumnReferenceRange.parse(text);
+}
 
 function tokenize(pathname) {
     return pathname && pathname.startsWith("/") ?
@@ -123,7 +131,7 @@ export default class SpreadsheetHistoryHash {
                             }
 
                             try {
-                                selection = SpreadsheetColumnReference.parse(sourceTokens.shift());
+                                selection = columnOrColumnRangeParse(sourceTokens.shift());
                             } catch(invalid) {
                                 errors("Column: " + invalid.message);
                                 valid = false;

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -2,6 +2,7 @@ import CharSequences from "../../CharSequences.js";
 import SpreadsheetCellRange from "../reference/SpreadsheetCellRange.js";
 import SpreadsheetCellReference from "../reference/SpreadsheetCellReference.js";
 import SpreadsheetColumnReference from "../reference/SpreadsheetColumnReference.js";
+import SpreadsheetColumnReferenceRange from "../reference/SpreadsheetColumnReferenceRange.js";
 import SpreadsheetHistoryHash from "./SpreadsheetHistoryHash.js";
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
@@ -12,6 +13,7 @@ const SPREADSHEET_NAME = new SpreadsheetName("spreadsheet-name-456");
 const CELL = SpreadsheetCellReference.parse("A1");
 const CELL_RANGE = SpreadsheetCellRange.parse("C3:D4");
 const COLUMN = SpreadsheetColumnReference.parse("B");
+const COLUMN_RANGE = SpreadsheetColumnReferenceRange.parse("B:C");
 const ROW = SpreadsheetRowReference.parse("2");
 const LABEL = SpreadsheetLabelName.parse("Label123");
 
@@ -461,6 +463,15 @@ parseAndStringifyTest(
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/B:C",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": COLUMN_RANGE,
     }
 );
 
@@ -1179,7 +1190,33 @@ mergeUpdatesFails([]);
         "/123abc/Untitled456/name"
     );
 
-// select.............................................................................................................
+    // column...........................................................................................................
+
+    mergeTest(
+        "/123abc/Untitled456/",
+        {
+            selection: COLUMN,
+        },
+        "/123abc/Untitled456/column/B"
+    );
+
+    mergeTest(
+        "/123abc/Untitled456/column/B",
+        {
+            selection: COLUMN_RANGE,
+        },
+        "/123abc/Untitled456/column/B:C"
+    );
+
+    mergeTest(
+        "/123abc/Untitled456/column/B:D",
+        {
+            selection: COLUMN,
+        },
+        "/123abc/Untitled456/column/B"
+    );
+
+    // select.............................................................................................................
 
     mergeTest(
         "/123abc/Untitled456/select",

--- a/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
@@ -5,6 +5,7 @@ import SpreadsheetColumnOrRowReferenceRange from "./SpreadsheetColumnOrRowRefere
 import spreadsheetRangeParse from "./SpreadsheetRangeParser.js";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import SystemObject from "../../SystemObject.js";
+import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 
 
 const TYPE_NAME = "spreadsheet-column-reference-range";
@@ -61,11 +62,15 @@ export default class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOr
     testRow(rowReference) {
         Preconditions.requireInstance(rowReference, SpreadsheetRowReference, "rowReference");
 
-        return true;
+        return false;
     }
 
     toQueryStringParameterSelectionType() {
         return "column-range";
+    }
+
+    toSelectionHashToken() {
+        return SpreadsheetHistoryHash.COLUMN + "/" + this;
     }
 
     typeName() {

--- a/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.test.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.test.js
@@ -244,9 +244,9 @@ function testRowAndCheck(label, range, rowReference, expected) {
     });
 }
 
-testRowAndCheck("left", JSON, "1", true);
-testRowAndCheck("left", JSON, "2", true);
-testRowAndCheck("left", JSON, "3", true);
+testRowAndCheck("left", JSON, "1", false);
+testRowAndCheck("left", JSON, "2", false);
+testRowAndCheck("left", JSON, "3", false);
 
 // helpers..............................................................................................................
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1108
- HistoryHash support for column ranges

- Changed SpreadsheetColumnReferenceRange.testRow always returns false so viewport rows are not selected