### PR TITLE
History hash row range support

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -1239,6 +1239,22 @@ context(
                 .should("have.css", "background-color", SELECTED_COLOR);
         });
 
+        // row range...................................................................................................
+
+        it("row range history hash", () => {
+            spreadsheetEmpty();
+
+            hashAppend("/row/2:3");
+
+            hash()
+                .should('match', /.*\/.*\/row\/2:3/);
+
+            row("2")
+                .should("have.css", "background-color", SELECTED_COLOR);
+            row("3")
+                .should("have.css", "background-color", SELECTED_COLOR);
+        });
+
         // select.....................................................................................................
 
         it("Select using hash initial appearance", () => {

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -7,6 +7,7 @@ import SpreadsheetColumnReferenceRange from "../reference/SpreadsheetColumnRefer
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
 import SpreadsheetRowReference from "../reference/SpreadsheetRowReference.js";
+import SpreadsheetRowReferenceRange from "../reference/SpreadsheetRowReferenceRange.js";
 import SpreadsheetSelection from "../reference/SpreadsheetSelection.js";
 
 function columnOrColumnRangeParse(text) {
@@ -14,6 +15,13 @@ function columnOrColumnRangeParse(text) {
     return -1 === colon ?
         SpreadsheetColumnReference.parse(text) :
         SpreadsheetColumnReferenceRange.parse(text);
+}
+
+function rowOrRowRangeParse(text) {
+    const colon = text.indexOf(":");
+    return -1 === colon ?
+        SpreadsheetRowReference.parse(text) :
+        SpreadsheetRowReferenceRange.parse(text);
 }
 
 function tokenize(pathname) {
@@ -160,7 +168,7 @@ export default class SpreadsheetHistoryHash {
                             }
 
                             try {
-                                selection = SpreadsheetRowReference.parse(sourceTokens.shift());
+                                selection = rowOrRowRangeParse(sourceTokens.shift());
                             } catch(invalid) {
                                 errors("Row: " + invalid.message);
                                 valid = false;

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -7,6 +7,7 @@ import SpreadsheetHistoryHash from "./SpreadsheetHistoryHash.js";
 import SpreadsheetLabelName from "../reference/SpreadsheetLabelName.js";
 import SpreadsheetName from "../SpreadsheetName.js";
 import SpreadsheetRowReference from "../reference/SpreadsheetRowReference.js";
+import SpreadsheetRowReferenceRange from "../reference/SpreadsheetRowReferenceRange.js";
 
 const ID = "spreadsheet-id-123";
 const SPREADSHEET_NAME = new SpreadsheetName("spreadsheet-name-456");
@@ -15,6 +16,7 @@ const CELL_RANGE = SpreadsheetCellRange.parse("C3:D4");
 const COLUMN = SpreadsheetColumnReference.parse("B");
 const COLUMN_RANGE = SpreadsheetColumnReferenceRange.parse("B:C");
 const ROW = SpreadsheetRowReference.parse("2");
+const ROW_RANGE = SpreadsheetRowReferenceRange.parse("2:3");
 const LABEL = SpreadsheetLabelName.parse("Label123");
 
 // validate................................................................................................................
@@ -491,6 +493,15 @@ parseAndStringifyTest(
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
         "selection": ROW,
+    }
+);
+
+parseAndStringifyTest(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2:3",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": ROW_RANGE,
     }
 );
 
@@ -1214,6 +1225,32 @@ mergeUpdatesFails([]);
             selection: COLUMN,
         },
         "/123abc/Untitled456/column/B"
+    );
+
+    // row...........................................................................................................
+
+    mergeTest(
+        "/123abc/Untitled456/",
+        {
+            selection: ROW,
+        },
+        "/123abc/Untitled456/row/2"
+    );
+    
+    mergeTest(
+        "/123abc/Untitled456/row/2",
+        {
+            selection: ROW_RANGE,
+        },
+        "/123abc/Untitled456/row/2:3"
+    );
+    
+    mergeTest(
+        "/123abc/Untitled456/row/2:3",
+        {
+            selection: ROW,
+        },
+        "/123abc/Untitled456/row/2"
     );
 
     // select.............................................................................................................

--- a/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
@@ -2,10 +2,10 @@ import Preconditions from "../../Preconditions.js";
 import SpreadsheetCellReference from "./SpreadsheetCellReference";
 import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
 import SpreadsheetColumnOrRowReferenceRange from "./SpreadsheetColumnOrRowReferenceRange.js";
+import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 import spreadsheetRangeParse from "./SpreadsheetRangeParser.js";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import SystemObject from "../../SystemObject.js";
-
 
 const TYPE_NAME = "spreadsheet-row-reference-range";
 /**
@@ -54,7 +54,7 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
     testColumn(columnReference) {
         Preconditions.requireInstance(columnReference, SpreadsheetColumnReference, "columnReference");
 
-        return true;
+        return false;
     }
 
     testRow(rowReference) {
@@ -66,6 +66,10 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
 
     toQueryStringParameterSelectionType() {
         return "row-range";
+    }
+
+    toSelectionHashToken() {
+        return SpreadsheetHistoryHash.ROW + "/" + this;
     }
 
     typeName() {

--- a/src/spreadsheet/reference/SpreadsheetRowReferenceRange.test.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReferenceRange.test.js
@@ -218,9 +218,9 @@ function testColumnAndCheck(label, range, columnReference, expected) {
     });
 }
 
-testColumnAndCheck("A", JSON, "A", true);
-testColumnAndCheck("B", JSON, "B", true);
-testColumnAndCheck("C", JSON, "C", true);
+testColumnAndCheck("A", JSON, "A", false);
+testColumnAndCheck("B", JSON, "B", false);
+testColumnAndCheck("C", JSON, "C", false);
 
 // testRow...........................................................................................................
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1136
- HistoryHash support for row ranges

- SpreadsheetRowReferenceRange.testColumn always false, so rendering viewport doesnt select any column header.