### PR TITLE
SpreadsheetMetadata.SELECTION SpreadsheetViewportSelection

### DIFF
--- a/cypress/integration/App.spec.js
+++ b/cypress/integration/App.spec.js
@@ -695,6 +695,34 @@ context(
             cellFormattedTextCheck(C3, "88."); // 4 * 22
         });
 
+        it("Label history hash navigate to label", () => {
+            spreadsheetEmpty();
+            hash()
+                .should('match', /.*\/Untitled/);
+
+            // create a new label
+            hashAppend("/label/NavigateToLabel123");
+
+            labelMappingReferenceTextField()
+                .type("A1");
+
+            labelMappingLabelSaveButton()
+                .click();
+
+            labelMappingLabelCloseButton()
+                .click();
+
+            // navigate
+            hashAppend("/cell/NavigateToLabel123");
+
+            cell(A1)
+                .should("have.focus");
+            column("A")
+                .should("have.css", "background-color", SELECTED_COLOR);
+            row("1")
+                .should("have.css", "background-color", SELECTED_COLOR);
+        });
+
         function labelDialogCheck(title,
                                   labelText,
                                   labelHelperText,

--- a/src/spreadsheet/engine/SpreadsheetDelta.js
+++ b/src/spreadsheet/engine/SpreadsheetDelta.js
@@ -115,6 +115,16 @@ export default class SpreadsheetDelta extends SystemObject {
         return this.labelsValue.slice();
     }
 
+    labelToReference() {
+        const map = new Map();
+
+        this.labels().forEach(m => {
+            map.set(m.label().toString(), m.reference());
+        });
+
+        return new ImmutableMap(map);
+    }
+
     cellToLabels() {
         const cellToLabels = new Map();
 

--- a/src/spreadsheet/engine/SpreadsheetDelta.test.js
+++ b/src/spreadsheet/engine/SpreadsheetDelta.test.js
@@ -422,6 +422,32 @@ test("cellToLabels() no labels", () => {
         .toBeUndefined();
 });
 
+// labelToReference.........................................................................................................
+
+test("labelToReference() several labels", () => {
+    const labelToReference = delta().labelToReference();
+
+    expect(labelToReference.get(label1()))
+        .toStrictEqual(a1().reference());
+
+    expect(labelToReference.get(label2()))
+        .toStrictEqual(a1().reference());
+});
+
+test("labelToReference() 1 label", () => {
+    const labelToReference = delta().labelToReference();
+
+    expect(labelToReference.get(label3()))
+        .toStrictEqual(b2().reference());
+});
+
+test("labelToReference() no labels", () => {
+    const labelToReference = delta().labelToReference();
+
+    expect(labelToReference.get(SpreadsheetLabelName.parse("Unknown")))
+        .toBeUndefined();
+});
+
 // toJson...............................................................................................................
 
 test("toJson only 1 cell", () => {

--- a/src/spreadsheet/meta/SpreadsheetMetadata.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.js
@@ -16,10 +16,10 @@ import SpreadsheetDateTimeFormatPattern from "../format/SpreadsheetDateTimeForma
 import SpreadsheetDateTimeParsePatterns from "../format/SpreadsheetDateTimeParsePatterns.js";
 import SpreadsheetNumberFormatPattern from "../format/SpreadsheetNumberFormatPattern.js";
 import SpreadsheetNumberParsePatterns from "../format/SpreadsheetNumberParsePatterns.js";
-import SpreadsheetSelection from "../reference/SpreadsheetSelection.js";
 import SpreadsheetTextFormatPattern from "../format/SpreadsheetTextFormatPattern.js";
 import SpreadsheetTimeFormatPattern from "../format/SpreadsheetTimeFormatPattern.js";
 import SpreadsheetTimeParsePatterns from "../format/SpreadsheetTimeParsePatterns.js";
+import SpreadsheetViewportSelection from "../reference/SpreadsheetViewportSelection.js";
 import SystemObject from "../../SystemObject.js";
 import TextStyle from "../../text/TextStyle";
 
@@ -268,7 +268,7 @@ export default class SpreadsheetMetadata extends SystemObject {
                     unmarshaller = RoundingMode.fromJson;
                     break;
                 case SpreadsheetMetadata.SELECTION:
-                    unmarshaller = SystemObject.fromJsonWithType;
+                    unmarshaller = SpreadsheetViewportSelection.fromJson;
                     break;
                 case SpreadsheetMetadata.SPREADSHEET_ID:
                     unmarshaller = null;
@@ -448,7 +448,7 @@ export default class SpreadsheetMetadata extends SystemObject {
                 expectedClass = RoundingMode;
                 break;
             case SpreadsheetMetadata.SELECTION:
-                expectedClass = SpreadsheetSelection;
+                expectedClass = SpreadsheetViewportSelection;
                 break;
             case SpreadsheetMetadata.SPREADSHEET_ID:
                 setFails(propertyName);
@@ -654,7 +654,7 @@ export default class SpreadsheetMetadata extends SystemObject {
 
             switch(key) {
                 case SpreadsheetMetadata.SELECTION:
-                    valueJson = value.toJsonWithType();
+                    valueJson = value.toJson();
                     break;
                 default:
                     valueJson = (value.toJson && value.toJson()) || value;

--- a/src/spreadsheet/reference/SpreadsheetCellRange.js
+++ b/src/spreadsheet/reference/SpreadsheetCellRange.js
@@ -56,10 +56,18 @@ export default class SpreadsheetCellRange extends SpreadsheetExpressionReference
             this;
     }
 
+    setAnchorConditional(anchor) {
+        return this.setAnchor(anchor);
+    }
+
     checkAnchor(anchor) {
         SpreadsheetSelection.checkAnyAnchor(
             anchor,
             [
+                SpreadsheetViewportSelectionAnchor.LEFT,
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                SpreadsheetViewportSelectionAnchor.TOP,
+                SpreadsheetViewportSelectionAnchor.BOTTOM,
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT,
                 SpreadsheetViewportSelectionAnchor.TOP_RIGHT,
                 SpreadsheetViewportSelectionAnchor.BOTTOM_LEFT,

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -11,10 +11,10 @@ import SpreadsheetFormula from "../SpreadsheetFormula.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetRowReference from "./SpreadsheetRowReference";
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
+import SpreadsheetViewportSelectionAnchor from "./SpreadsheetViewportSelectionAnchor.js";
 import SystemObject from "../../SystemObject.js";
 import TextStyle from "../../text/TextStyle.js";
 import Text from "../../text/Text.js";
-
 
 const TYPE_NAME = "spreadsheet-cell-reference";
 
@@ -199,6 +199,10 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
 
     // viewport keyboard................................................................................................
 
+    setAnchorConditional(anchor) {
+        return this.setAnchor(); // ignore anchor
+    }
+
     checkAnchor(anchor) {
         SpreadsheetSelection.checkNoAnchor(anchor);
     }
@@ -219,44 +223,48 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
         return this.addRowSaturated(+1);
     }
 
-    extendRangeLeft(viewportHome) {
+    extendRangeLeft(anchor, viewportHome) {
         const c = this.column();
         const r = this.row();
 
         return new SpreadsheetCellRange(
             c.addSaturated(-1).setRow(r),
             c.setRow(r)
-        ).cellOrRange();
+        ).cellOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.RIGHT)
     }
 
-    extendRangeRight(viewportHome) {
+    extendRangeRight(anchor, viewportHome) {
         const c = this.column();
         const r = this.row();
 
         return new SpreadsheetCellRange(
             c.setRow(r),
             c.addSaturated(+1).setRow(r),
-        ).cellOrRange();
+        ).cellOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.LEFT)
     }
 
-    extendRangeUp(viewportHome) {
+    extendRangeUp(anchor, viewportHome) {
         const c = this.column();
         const r = this.row();
 
         return new SpreadsheetCellRange(
             r.addSaturated(-1).setColumn(c),
             c.setRow(r)
-        ).cellOrRange();
+        ).cellOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.BOTTOM)
     }
 
-    extendRangeDown(viewportHome) {
+    extendRangeDown(anchor, viewportHome) {
         const c = this.column();
         const r = this.row();
 
         return new SpreadsheetCellRange(
             c.setRow(r),
             r.addSaturated(+1).setColumn(c),
-        ).cellOrRange();
+        ).cellOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.TOP)
     }
 
     selectionEnter(giveFormulaFocus) {
@@ -332,7 +340,7 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
      * Clicking on a cell selects it.
      */
     onViewportClick(setSelection, giveFocus) {
-        setSelection(this);
+        setSelection(this.setAnchor());
         //giveFocus();
     }
 

--- a/src/spreadsheet/reference/SpreadsheetCellReference.test.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.test.js
@@ -1,9 +1,11 @@
 import Keys from "../../Keys.js";
+import SpreadsheetCellRange from "./SpreadsheetCellRange.js";
 import SpreadsheetCellReference from "./SpreadsheetCellReference";
 import SpreadsheetColumnReference from "./SpreadsheetColumnReference";
 import SpreadsheetRowReference from "./SpreadsheetRowReference";
+import SpreadsheetViewportSelectionAnchor from "./SpreadsheetViewportSelectionAnchor.js";
 import systemObjectTesting from "../../SystemObjectTesting.js";
-import SpreadsheetCellRange from "./SpreadsheetCellRange.js";
+
 
 function column() {
     return SpreadsheetColumnReference.parse("A");
@@ -394,7 +396,7 @@ test("addRowSaturated delta overflow", () => {
 
 // extendRangeLeft......................................................................................................
 
-function testExtendRangeLeft(cell, expected) {
+function testExtendRangeLeft(cell, expected, anchor) {
     const h = home();
 
     test("extendRangeLeft " + cell + " home=" + h,
@@ -404,17 +406,18 @@ function testExtendRangeLeft(cell, expected) {
             ).toStrictEqual(
                 SpreadsheetCellRange.parse(expected)
                     .cellOrRange()
+                    .setAnchorConditional(anchor)
             )
         });
 }
 
 testExtendRangeLeft("A1", "A1");
-testExtendRangeLeft("B2", "A2:B2");
-testExtendRangeLeft("C3", "B3:C3");
+testExtendRangeLeft("B2", "A2:B2", SpreadsheetViewportSelectionAnchor.RIGHT);
+testExtendRangeLeft("C3", "B3:C3", SpreadsheetViewportSelectionAnchor.RIGHT);
 
 // extendRangeRight......................................................................................................
 
-function testExtendRangeRight(cell, expected) {
+function testExtendRangeRight(cell, expected, anchor) {
     const h = home();
 
     test("extendRangeRight " + cell + " home=" + h,
@@ -424,17 +427,18 @@ function testExtendRangeRight(cell, expected) {
             ).toStrictEqual(
                 SpreadsheetCellRange.parse(expected)
                     .cellOrRange()
+                    .setAnchorConditional(anchor)
             )
         });
 }
 
 testExtendRangeRight("XFD1", "XFD1");
-testExtendRangeRight("A1", "A1:B1");
-testExtendRangeRight("B2", "B2:C2");
+testExtendRangeRight("A1", "A1:B1", SpreadsheetViewportSelectionAnchor.LEFT);
+testExtendRangeRight("B2", "B2:C2", SpreadsheetViewportSelectionAnchor.LEFT);
 
 // extendRangeUp......................................................................................................
 
-function testExtendRangeUp(cell, expected) {
+function testExtendRangeUp(cell, expected, anchor) {
     const h = home();
 
     test("extendRangeUp " + cell + " home=" + h,
@@ -444,17 +448,18 @@ function testExtendRangeUp(cell, expected) {
             ).toStrictEqual(
                 SpreadsheetCellRange.parse(expected)
                     .cellOrRange()
+                    .setAnchorConditional(anchor)
             )
         });
 }
 
 testExtendRangeUp("A1", "A1");
-testExtendRangeUp("B2", "B1:B2");
-testExtendRangeUp("C3", "C2:C3");
+testExtendRangeUp("B2", "B1:B2", SpreadsheetViewportSelectionAnchor.BOTTOM);
+testExtendRangeUp("C3", "C2:C3", SpreadsheetViewportSelectionAnchor.BOTTOM);
 
 // extendRangeDown......................................................................................................
 
-function testExtendRangeDown(cell, expected) {
+function testExtendRangeDown(cell, expected, anchor) {
     const h = home();
 
     test("extendRangeDown " + cell + " home=" + h,
@@ -464,14 +469,15 @@ function testExtendRangeDown(cell, expected) {
             ).toStrictEqual(
                 SpreadsheetCellRange.parse(expected)
                     .cellOrRange()
+                    .setAnchorConditional(anchor)
             )
         });
 }
 
 testExtendRangeDown("A1048576", "A1048576");
 testExtendRangeDown("B1048576", "B1048576");
-testExtendRangeDown("A1", "A1:A2");
-testExtendRangeDown("B2", "B2:B3");
+testExtendRangeDown("A1", "A1:A2", SpreadsheetViewportSelectionAnchor.TOP);
+testExtendRangeDown("B2", "B2:B3", SpreadsheetViewportSelectionAnchor.TOP);
 
 // testCell SpreadsheetCellReference........................................................................................
 
@@ -558,7 +564,7 @@ test("onViewportClickAndTest cell=A1", () => {
         );
     expect(state)
         .toStrictEqual({
-            selection: reference.toString(),
+            selection: reference.setAnchor().toString(),
             giveFormulaFocus: false,
         });
 });
@@ -568,15 +574,15 @@ test("onViewportClickAndTest cell=A1", () => {
 const SELECT_RANGE_FALSE = false;
 const SELECT_RANGE_TRUE = true;
 
-function testOnViewportKeyDown(reference, key, selectRange, viewportHome, setSelection, giveFormulaFocus) {
-    test("testOnViewportKeyDown cell=" + reference + " key=" + key + " selectRange=" + selectRange + " home=" + viewportHome, () => {
+function testOnViewportKeyDown(cell, key, selectRange, viewportHome, setSelection, anchor, giveFormulaFocus) {
+    test("testOnViewportKeyDown cell=" + cell + " key=" + key + " selectRange=" + selectRange + " anchor=" + anchor + " home=" + viewportHome, () => {
 
         const state = {
-            selection: SpreadsheetCellRange.parse(reference).cellOrRange().toString(),
+            selection: SpreadsheetCellReference.parse(cell).setAnchor().toString(),
             giveFormulaFocus: false,
         };
 
-        SpreadsheetCellReference.parse(reference)
+        SpreadsheetCellReference.parse(cell)
             .onViewportKeyDown(
                 key,
                 selectRange,
@@ -586,35 +592,35 @@ function testOnViewportKeyDown(reference, key, selectRange, viewportHome, setSel
             );
         expect(state)
             .toStrictEqual({
-                selection: setSelection && SpreadsheetCellRange.parse(setSelection).cellOrRange().toString(),
+                selection: setSelection && SpreadsheetCellRange.parse(setSelection).cellOrRange().setAnchorConditional(anchor).toString(),
                 giveFormulaFocus: giveFormulaFocus,
             });
     });
 }
 
-testOnViewportKeyDown("B2", "A", SELECT_RANGE_FALSE, "A1", "B2", false);
-testOnViewportKeyDown("B2", "A", SELECT_RANGE_TRUE, "A1", "B2", false);
+testOnViewportKeyDown("B2", "A", SELECT_RANGE_FALSE, "A1", "B2", null, false);
+testOnViewportKeyDown("B2", "A", SELECT_RANGE_TRUE, "A1", "B2", null, false);
 
-testOnViewportKeyDown("B2", Keys.ESCAPE, SELECT_RANGE_FALSE, "B2", null, false);
-testOnViewportKeyDown("B2", Keys.ESCAPE, SELECT_RANGE_TRUE, "B2", null, false);
-testOnViewportKeyDown("B2", Keys.ENTER, SELECT_RANGE_FALSE, "B2", "B2", true);
-testOnViewportKeyDown("B2", Keys.ENTER, SELECT_RANGE_TRUE, "B2", "B2", true);
+testOnViewportKeyDown("B2", Keys.ESCAPE, SELECT_RANGE_FALSE, "B2", null, null, false);
+testOnViewportKeyDown("B2", Keys.ESCAPE, SELECT_RANGE_TRUE, "B2", null, null, false);
+testOnViewportKeyDown("B2", Keys.ENTER, SELECT_RANGE_FALSE, "B2", "B2", null, true);
+testOnViewportKeyDown("B2", Keys.ENTER, SELECT_RANGE_TRUE, "B2", "B2", null, true);
 
-testOnViewportKeyDown("B2", Keys.ARROW_LEFT, SELECT_RANGE_FALSE, "B2", "A2", false);
-testOnViewportKeyDown("B2", Keys.ARROW_RIGHT, SELECT_RANGE_FALSE, "B2", "C2", false);
-testOnViewportKeyDown("B2", Keys.ARROW_UP, SELECT_RANGE_FALSE, "B2", "B1", false);
-testOnViewportKeyDown("B2", Keys.ARROW_DOWN, SELECT_RANGE_FALSE, "B2", "B3", false);
+testOnViewportKeyDown("B2", Keys.ARROW_LEFT, SELECT_RANGE_FALSE, "B2", "A2", null, false);
+testOnViewportKeyDown("B2", Keys.ARROW_RIGHT, SELECT_RANGE_FALSE, "B2", "C2", null, false);
+testOnViewportKeyDown("B2", Keys.ARROW_UP, SELECT_RANGE_FALSE, "B2", "B1", null, false);
+testOnViewportKeyDown("B2", Keys.ARROW_DOWN, SELECT_RANGE_FALSE, "B2", "B3", null, false);
 
-testOnViewportKeyDown("A1", Keys.ARROW_LEFT, SELECT_RANGE_FALSE, "A1", "A1", false);
-testOnViewportKeyDown("A1", Keys.ARROW_UP, SELECT_RANGE_FALSE, "A1", "A1", false);
+testOnViewportKeyDown("A1", Keys.ARROW_LEFT, SELECT_RANGE_FALSE, "A1", "A1", null, false);
+testOnViewportKeyDown("A1", Keys.ARROW_UP, SELECT_RANGE_FALSE, "A1", "A1", null, false);
 
-testOnViewportKeyDown("B2", Keys.ARROW_LEFT, SELECT_RANGE_TRUE, "B2", "A2:B2", false);
-testOnViewportKeyDown("B2", Keys.ARROW_RIGHT, SELECT_RANGE_TRUE, "B2", "B2:C2", false);
-testOnViewportKeyDown("B2", Keys.ARROW_UP, SELECT_RANGE_TRUE, "B2", "B1:B2", false);
-testOnViewportKeyDown("B2", Keys.ARROW_DOWN, SELECT_RANGE_TRUE, "B2", "B2:B3", false);
+testOnViewportKeyDown("B2", Keys.ARROW_LEFT, SELECT_RANGE_TRUE, "B2", "A2:B2", SpreadsheetViewportSelectionAnchor.RIGHT, false);
+testOnViewportKeyDown("B2", Keys.ARROW_RIGHT, SELECT_RANGE_TRUE, "B2", "B2:C2", SpreadsheetViewportSelectionAnchor.LEFT, false);
+testOnViewportKeyDown("B2", Keys.ARROW_UP, SELECT_RANGE_TRUE, "B2", "B1:B2", SpreadsheetViewportSelectionAnchor.BOTTOM, false);
+testOnViewportKeyDown("B2", Keys.ARROW_DOWN, SELECT_RANGE_TRUE, "B2", "B2:B3", SpreadsheetViewportSelectionAnchor.TOP, false);
 
-testOnViewportKeyDown("A1", Keys.ARROW_LEFT, SELECT_RANGE_TRUE, "A1", "A1", false);
-testOnViewportKeyDown("A1", Keys.ARROW_UP, SELECT_RANGE_TRUE, "A1", "A1", false);
+testOnViewportKeyDown("A1", Keys.ARROW_LEFT, SELECT_RANGE_TRUE, "A1", "A1", null, false);
+testOnViewportKeyDown("A1", Keys.ARROW_UP, SELECT_RANGE_TRUE, "A1", "A1", null, false);
 
 // equals................................................................................................................
 

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
@@ -1,8 +1,8 @@
 import Preconditions from "../../Preconditions.js";
 import React from "react";
+import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
-import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
 import TableCell from "@material-ui/core/TableCell";
 
 // default header cell styles
@@ -113,6 +113,10 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
         }</TableCell>
     }
 
+    setAnchorConditional(anchor) {
+        return this.setAnchor(); // not a range ignore anchor
+    }
+
     checkAnchor(anchor) {
         SpreadsheetSelection.checkNoAnchor(anchor);
     }
@@ -125,7 +129,7 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
      * Clicking on a column or row selects it.
      */
     onViewportClick(setSelection, giveFormulaFocus) {
-        setSelection(this);
+        setSelection(this.setAnchor());
     }
 
     equals(other) {

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReferenceRange.js
@@ -30,6 +30,10 @@ export default class SpreadsheetColumnOrRowReferenceRange extends SpreadsheetSel
             begin.toJson() + ":" + end.toJson();
     }
 
+    setAnchorConditional(anchor) {
+        return this.setAnchor(anchor);
+    }
+
     selectEnter(giveFormulaFocus) {
         // ENTER currently is a NOP but will change to perhaps popup a menu
     }

--- a/src/spreadsheet/reference/SpreadsheetColumnReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReference.js
@@ -6,6 +6,7 @@ import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
+import SpreadsheetViewportSelectionAnchor from "./SpreadsheetViewportSelectionAnchor.js";
 import SystemObject from "../../SystemObject.js";
 
 const A = 65;
@@ -76,31 +77,34 @@ export default class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRe
             .setColumn(this);
     }
 
-    extendRangeLeft(viewportHome) {
+    extendRangeLeft(anchor, viewportHome) {
         return new SpreadsheetColumnReferenceRange(
             this.addSaturated(-1),
             this
-        ).columnOrRange();
+        ).columnOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.RIGHT);
     }
 
-    extendRangeRight(viewportHome) {
+    extendRangeRight(anchor, viewportHome) {
         return new SpreadsheetColumnReferenceRange(
             this,
             this.addSaturated(+1)
-        ).columnOrRange();
+        ).columnOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.LEFT);
     }
 
-    extendRangeUp(viewportHome) {
+    extendRangeUp(anchor, viewportHome) {
         Preconditions.requireInstance(viewportHome, SpreadsheetCellReference, "viewportHome");
 
-        return this;
+        return this.setAnchor();
     }
 
-    extendRangeDown(viewportHome) {
+    extendRangeDown(anchor, viewportHome) {
         Preconditions.requireInstance(viewportHome, SpreadsheetCellReference, "viewportHome");
 
         return viewportHome.row()
-            .setColumn(this);
+            .setColumn(this)
+            .setAnchor();
     }
 
     testCell(cellReference) {

--- a/src/spreadsheet/reference/SpreadsheetLabelName.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelName.js
@@ -4,7 +4,6 @@ import Preconditions from "../../Preconditions.js";
 import SpreadsheetCellReference from "./SpreadsheetCellReference.js";
 import SpreadsheetCellReferenceOrLabelName from "./SpreadsheetCellReferenceOrLabelName.js";
 import SpreadsheetLabelMapping from "./SpreadsheetLabelMapping.js";
-import SpreadsheetViewportSelection from "./SpreadsheetViewportSelection.js";
 import SystemObject from "../../SystemObject.js";
 
 const TYPE_NAME = "spreadsheet-label-name";
@@ -74,8 +73,12 @@ export default class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabe
         return new SpreadsheetLabelMapping(this, reference);
     }
 
+    setAnchorConditional(anchor) {
+        return this.setAnchor(anchor);// keep
+    }
+
     checkAnchor(anchor) {
-        throw new Error("Label " + this + " cannot be appear within " + SpreadsheetViewportSelection.name);
+        // nop
     }
 
     testCell(cellReference) {

--- a/src/spreadsheet/reference/SpreadsheetRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReference.js
@@ -7,6 +7,7 @@ import SpreadsheetHistoryHash from "../history/SpreadsheetHistoryHash.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetRowReferenceRange from "./SpreadsheetRowReferenceRange.js";
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
+import SpreadsheetViewportSelectionAnchor from "./SpreadsheetViewportSelectionAnchor.js";
 import SystemObject from "../../SystemObject.js";
 
 const TYPE_NAME = "spreadsheet-row-reference";
@@ -78,31 +79,34 @@ export default class SpreadsheetRowReference extends SpreadsheetColumnOrRowRefer
         return this.addSaturated(+1);
     }
 
-    extendRangeLeft(viewportHome) {
+    extendRangeLeft(anchor, viewportHome) {
         Preconditions.requireInstance(viewportHome, SpreadsheetCellReference, "viewportHome");
 
-        return this;
+        return this.setAnchor();
     }
 
-    extendRangeRight(viewportHome) {
+    extendRangeRight(anchor, viewportHome) {
         Preconditions.requireInstance(viewportHome, SpreadsheetCellReference, "viewportHome");
 
         return viewportHome.column()
-            .setRow(this);
+            .setRow(this)
+            .setAnchor()
     }
 
-    extendRangeUp(viewportHome) {
+    extendRangeUp(anchor, viewportHome) {
         return new SpreadsheetRowReferenceRange(
             this.addSaturated(-1),
             this
-        ).rowOrRange();
+        ).rowOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.BOTTOM)
     }
 
-    extendRangeDown(viewportHome) {
+    extendRangeDown(anchor, viewportHome) {
         return new SpreadsheetRowReferenceRange(
             this,
             this.addSaturated(+1),
-        ).rowOrRange();
+        ).rowOrRange()
+            .setAnchorConditional(SpreadsheetViewportSelectionAnchor.TOP)
     }
 
     testCell(cellReference) {

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -1,7 +1,8 @@
 import CharSequences from "../../CharSequences.js";
 import Character from "../../Character.js";
-import SystemObject from "../../SystemObject.js";
 import Keys from "../../Keys.js";
+import SpreadsheetViewportSelection from "./SpreadsheetViewportSelection.js";
+import SystemObject from "../../SystemObject.js";
 
 /**
  * Common base class for several types in this namespace
@@ -10,6 +11,17 @@ export default class SpreadsheetSelection extends SystemObject {
 
     static reportInvalidCharacter(c, pos) {
         throw new Error("Invalid character " + CharSequences.quoteAndEscape(Character.fromJson(c)) + " at " + pos);
+    }
+
+    setAnchor(anchor) {
+        return new SpreadsheetViewportSelection(this, anchor);
+    }
+
+    /**
+     * If the sub class is a range, call setAnchor with the given anchor otherwise call with null.
+     */
+    setAnchorConditional(anchor) {
+        throw new Error("Not yet implemented");
     }
 
     checkAnchor(anchor) {
@@ -41,36 +53,36 @@ export default class SpreadsheetSelection extends SystemObject {
     /**
      * LEFT | RIGHT Arrow keys update the column selection or when down selects the first visible cell or ESC clears the current selection.
      */
-    onViewportKeyDown(key, selectRange, setSelection, giveFormulaFocus, viewportHome) {
+    onViewportKeyDown(key, selectRange, setSelection, giveFormulaFocus, anchor, viewportHome) {
         console.log("onViewportKeyDown: " + key + " " + this);
 
         switch(key) {
             case Keys.ARROW_LEFT:
                 setSelection(
                     selectRange ?
-                        this.extendRangeLeft(viewportHome) :
-                        this.navigateLeft(viewportHome)
+                        this.extendRangeLeft(anchor, viewportHome) :
+                        this.navigateLeft(viewportHome).setAnchor()
                 );
                 break;
             case Keys.ARROW_RIGHT:
                 setSelection(
                     selectRange ?
-                        this.extendRangeRight(viewportHome) :
-                        this.navigateRight(viewportHome)
+                        this.extendRangeRight(anchor, viewportHome) :
+                        this.navigateRight(viewportHome).setAnchor()
                 );
                 break;
             case Keys.ARROW_UP:
                 setSelection(
                     selectRange ?
-                        this.extendRangeUp(viewportHome) :
-                        this.navigateUp(viewportHome)
+                        this.extendRangeUp(anchor, viewportHome) :
+                        this.navigateUp(viewportHome).setAnchor()
                 );
                 break;
             case Keys.ARROW_DOWN:
                 setSelection(
                     selectRange ?
-                        this.extendRangeDown(viewportHome) :
-                        this.navigateDown(viewportHome)
+                        this.extendRangeDown(anchor, viewportHome) :
+                        this.navigateDown(viewportHome).setAnchor()
                 );
                 break;
             case Keys.ENTER:
@@ -85,35 +97,37 @@ export default class SpreadsheetSelection extends SystemObject {
         }
     }
 
-    extendRangeLeft(viewportHome) {
+    extendRangeLeft(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    extendRangeRight(viewportHome) {
+    extendRangeRight(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    extendRangeUp(viewportHome) {
+    extendRangeUp(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    extendRangeDown(viewportHome) {
+    extendRangeDown(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    navigateLeft(viewportHome) {
+    // all navigate methods must return SpreadsheetSelection
+
+    navigateLeft(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    navigateRight(viewportHome) {
+    navigateRight(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    navigateUp(viewportHome) {
+    navigateUp(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 
-    navigateDown(viewportHome) {
+    navigateDown(anchor, viewportHome) {
         throw new Error("Not yet implemented");
     }
 

--- a/src/spreadsheet/reference/SpreadsheetViewportSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetViewportSelection.js
@@ -58,7 +58,8 @@ export default class SpreadsheetViewportSelection extends SystemObject {
     }
 
     toString() {
-        return JSON.stringify(this.toJson());
+        const anchor = this.anchor();
+        return this.selection() + (anchor ? " " + anchor : "");
     }
 }
 

--- a/src/spreadsheet/reference/SpreadsheetViewportSelection.test.js
+++ b/src/spreadsheet/reference/SpreadsheetViewportSelection.test.js
@@ -37,6 +37,10 @@ function rowRange() {
     return SpreadsheetRowReferenceRange.parse("2:3");
 }
 
+function label() {
+    return SpreadsheetLabelName.parse("Label123");
+}
+
 function anchor() {
     return SpreadsheetViewportSelectionAnchor.TOP_LEFT;
 };
@@ -75,7 +79,6 @@ function testNew(selection, anchor) {
 }
 
 testNewFails(null, null, "Missing selection");
-testNewFails(SpreadsheetLabelName.parse("Label123"), null, "Label Label123 cannot be appear within SpreadsheetViewportSelection");
 
 // cell
 testNewFails(cell(), SpreadsheetViewportSelectionAnchor.TOP, "Expected no anchor got TOP");
@@ -89,14 +92,14 @@ testNewFails(cell(), SpreadsheetViewportSelectionAnchor.RIGHT);
 testNew(cell(), null);
 
 // cellRange
-testNewFails(cellRange(), SpreadsheetViewportSelectionAnchor.TOP, "Unknown anchor TOP, expected any of TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT");
+testNew(cellRange(), SpreadsheetViewportSelectionAnchor.TOP);
 testNew(cellRange(), SpreadsheetViewportSelectionAnchor.TOP_LEFT);
 testNew(cellRange(), SpreadsheetViewportSelectionAnchor.TOP_RIGHT);
-testNewFails(cellRange(), SpreadsheetViewportSelectionAnchor.BOTTOM);
+testNew(cellRange(), SpreadsheetViewportSelectionAnchor.BOTTOM);
 testNew(cellRange(), SpreadsheetViewportSelectionAnchor.BOTTOM_LEFT);
 testNew(cellRange(), SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
-testNewFails(cellRange(), SpreadsheetViewportSelectionAnchor.LEFT);
-testNewFails(cellRange(), SpreadsheetViewportSelectionAnchor.RIGHT);
+testNew(cellRange(), SpreadsheetViewportSelectionAnchor.LEFT);
+testNew(cellRange(), SpreadsheetViewportSelectionAnchor.RIGHT);
 testNewFails(cellRange(), null, "Missing anchor");
 
 // column
@@ -142,6 +145,17 @@ testNewFails(rowRange(), SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
 testNewFails(rowRange(), SpreadsheetViewportSelectionAnchor.LEFT);
 testNewFails(rowRange(), SpreadsheetViewportSelectionAnchor.RIGHT);
 testNewFails(rowRange(), null, "Missing anchor");
+
+// label
+testNew(label(), SpreadsheetViewportSelectionAnchor.TOP);
+testNew(label(), SpreadsheetViewportSelectionAnchor.TOP_LEFT);
+testNew(label(), SpreadsheetViewportSelectionAnchor.TOP_RIGHT);
+testNew(label(), SpreadsheetViewportSelectionAnchor.BOTTOM);
+testNew(label(), SpreadsheetViewportSelectionAnchor.BOTTOM_LEFT);
+testNew(label(), SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
+testNew(label(), SpreadsheetViewportSelectionAnchor.LEFT);
+testNew(label(), SpreadsheetViewportSelectionAnchor.RIGHT);
+testNew(label(), null);
 
 // fromJson.............................................................................................................
 


### PR DESCRIPTION
- includes selection support for history hash labels.
- SpreadsheetSelection.setAnchor(anchor)
- SpreadsheetViewportSelection.toString() changed to selecting space anchor was json form.
- give focus to column, cell and row on history hash change.
- Incomplete keyboard (shift) range selection in UI and tests.
- SpreadsheetDelta.labelToReference()