### PR TITLE
history hash cell/label/formula/save support

### DIFF
--- a/src/spreadsheet/SpreadsheetCell.js
+++ b/src/spreadsheet/SpreadsheetCell.js
@@ -2,9 +2,11 @@ import textNodeJsonSupportFromJson from "../text/TextNodeJsonSupport";
 import Equality from "../Equality.js";
 import Preconditions from "../Preconditions.js";
 import React from "react";
-import SpreadsheetCellReference from "./reference/SpreadsheetCellReference";
-import SpreadsheetFormula from "./SpreadsheetFormula";
+import SpreadsheetCellReference from "./reference/SpreadsheetCellReference.js";
 import SpreadsheetCellFormat from "./SpreadsheetCellFormat";
+import SpreadsheetCellReferenceOrLabelName from "./reference/SpreadsheetCellReferenceOrLabelName.js";
+import SpreadsheetFormula from "./SpreadsheetFormula";
+import SpreadsheetLabelName from "./reference/SpreadsheetLabelName.js";
 import SystemObject from "../SystemObject.js";
 import TableCell from "@material-ui/core/TableCell";
 import TextNode from "../text/TextNode";
@@ -42,10 +44,13 @@ export default class SpreadsheetCell extends SystemObject {
             case 0:
                 throw new Error("Missing reference");
             case 1:
-                const reference = keys[0];
-                const {formula, style, format, formatted} = json[reference];
+                const cellReferenceOrLabel = keys[0];
+                const {formula, style, format, formatted} = json[cellReferenceOrLabel];
 
-                return new SpreadsheetCell(SpreadsheetCellReference.fromJson(reference),
+                return new SpreadsheetCell(
+                    SpreadsheetCellReference.isCellReferenceText(cellReferenceOrLabel) ?
+                      SpreadsheetCellReference.fromJson(cellReferenceOrLabel) :
+                        SpreadsheetLabelName.fromJson(cellReferenceOrLabel),
                     SpreadsheetFormula.fromJson(formula),
                     (style && TextStyle.fromJson(style)) || TextStyle.EMPTY,
                     format != null ? SpreadsheetCellFormat.fromJson(format) : format,
@@ -57,7 +62,7 @@ export default class SpreadsheetCell extends SystemObject {
 
     constructor(reference, formula, style, format, formatted) {
         super();
-        Preconditions.requireInstance(reference, SpreadsheetCellReference, "reference");
+        Preconditions.requireInstance(reference, SpreadsheetCellReferenceOrLabelName, "reference");
         Preconditions.requireInstance(formula, SpreadsheetFormula, "formula");
         Preconditions.requireInstance(style, TextStyle, "style");
         Preconditions.optionalInstance(format, SpreadsheetCellFormat, "format");

--- a/src/spreadsheet/SpreadsheetCell.test.js
+++ b/src/spreadsheet/SpreadsheetCell.test.js
@@ -3,13 +3,14 @@ import React from "react";
 import SpreadsheetCell from "./SpreadsheetCell.js";
 import SpreadsheetCellFormat from "./SpreadsheetCellFormat";
 import SpreadsheetCellReference from "./reference/SpreadsheetCellReference";
+import SpreadsheetCellReferenceOrLabelName from "./reference/SpreadsheetCellReferenceOrLabelName.js";
 import SpreadsheetFormula from "./SpreadsheetFormula";
+import SpreadsheetLabelName from "./reference/SpreadsheetLabelName.js";
 import systemObjectTesting from "../SystemObjectTesting.js";
 import TableCell from "@material-ui/core/TableCell";
 import Text from "../text/Text";
 import TextStyle from "../text/TextStyle";
 import Tooltip from "@material-ui/core/Tooltip";
-import SpreadsheetLabelName from "./reference/SpreadsheetLabelName.js";
 
 function cell() {
     return new SpreadsheetCell(reference(),
@@ -189,6 +190,29 @@ test("create ABSOLUTE reference, formula, style, format, formatted", () => {
         f3,
         {
             "B78": {
+                formula: f.toJson(),
+                style: s.toJson(),
+                format: f2.toJson(),
+                formatted: f3.toJson()
+            }
+        })
+});
+
+test("create label, formula, style, format, formatted", () => {
+    const r = SpreadsheetLabelName.parse("Label123");
+    const f = formula();
+    const s = style();
+    const f2 = format();
+    const f3 = formatted();
+
+    check(new SpreadsheetCell(r, f, s, f2, f3),
+        r,
+        f,
+        s,
+        f2,
+        f3,
+        {
+            "Label123": {
                 formula: f.toJson(),
                 style: s.toJson(),
                 format: f2.toJson(),
@@ -524,7 +548,7 @@ test("equals equivalent true #2", () => {
 
 function check(cell, reference, formula, style, format, formatted, json) {
     expect(cell.reference()).toStrictEqual(reference);
-    expect(cell.reference()).toBeInstanceOf(SpreadsheetCellReference);
+    expect(cell.reference()).toBeInstanceOf(SpreadsheetCellReferenceOrLabelName);
 
     expect(cell.formula()).toStrictEqual(formula);
     expect(cell.formula()).toBeInstanceOf(SpreadsheetFormula);

--- a/src/spreadsheet/SpreadsheetFormulaWidget.js
+++ b/src/spreadsheet/SpreadsheetFormulaWidget.js
@@ -19,8 +19,7 @@ import TextField from '@material-ui/core/TextField';
 import TextStyle from "../text/TextStyle.js";
 
 /**
- * A widget that supports editing formula text. The widget is disabled when state.cellOrLabel is falsey.
- * An falsey value will disable the text box used to edit the formula text.
+ * A widget that supports editing formula text.
  * ENTER calls the setter, ESCAPE reloads the initial value(text).
  * <ul>
  *     <li>SpreadsheetCell cell: The cell being edited</li>
@@ -60,13 +59,13 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
     stateFromHistoryTokens(historyTokens) {
         console.log("historyTokens: " + SpreadsheetHistoryHash.stringify(historyTokens));
 
-        const selection = historyTokens[SpreadsheetHistoryHash.SELECTION];
-        const cellOrLabel = selection instanceof SpreadsheetCellReferenceOrLabelName && selection;
+        const selectionHistoryHash = historyTokens[SpreadsheetHistoryHash.SELECTION];
+        const selection = selectionHistoryHash instanceof SpreadsheetCellReferenceOrLabelName && selectionHistoryHash;
         const selectionAction = historyTokens[SpreadsheetHistoryHash.SELECTION_ACTION];
 
         return {
-            selection: cellOrLabel,
-            selectionAction: (cellOrLabel &&
+            selection: selection,
+            selectionAction: (selection &&
                 (selectionAction instanceof SpreadsheetFormulaLoadAndEditHistoryHashToken ||
                 selectionAction instanceof SpreadsheetFormulaSaveHistoryHashToken)) &&
                 selectionAction,
@@ -99,12 +98,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
             }
 
             if(save){
-                if(cellReference instanceof SpreadsheetCellReference){
-                    debugger;
-                    this.saveFormulaText(cellReference, selection, selectionAction.formulaText());
-                } else {
-                    console.log("Save request ignored because cell " + selection + " was not previous loaded");
-                }
+                this.saveFormulaText(cellReference, selection, selectionAction.formulaText());
                 selectionAction = new SpreadsheetFormulaLoadAndEditHistoryHashToken();
             }
 
@@ -128,7 +122,7 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
     }
 
     /**
-     * Loads the SpreadsheetDelta for the given cellOrLabel.
+     * Loads the SpreadsheetDelta for the given cell or label.
      */
     loadFormulaText(cellOrLabel) {
         console.log("loadFormulaText " + cellOrLabel);

--- a/src/spreadsheet/reference/SpreadsheetLabelName.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelName.js
@@ -102,6 +102,10 @@ export default class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabe
         return "label";
     }
 
+    toRelative() {
+        return this;
+    }
+
     toJson() {
         return this.toString();
     }


### PR DESCRIPTION
- requires API that takes only formula, currently requires a load before save.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1256
- Update SpreadsheetFormulaWidget to use PUT /cell/ cell or label / formula