### PR TITLE
SpreadsheetViewportWidget onClick updates history hash with selection…

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -528,13 +528,17 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
         ];
     }
 
+    /**
+     * Clicking on any selection component within a viewport updates the history hash and clears the selection action.
+     */
     onClick(e) {
         const selection = this.findEventTargetSelection(e.target);
         if(selection){
-            selection.onViewportClick(
-                (s) => this.saveSelection(s),
-                () => this.giveFormulaTextBoxFocus(selection),
-            );
+            const tokens = {};
+            tokens[SpreadsheetHistoryHash.SELECTION] = selection;
+            tokens[SpreadsheetHistoryHash.SELECTION_ACTION] = null;
+            
+            this.historyParseMergeAndPush(tokens);
         }
     }
 

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -329,15 +329,6 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
         return this.viewportId() + "-Tooltip";
     }
 
-    /**
-     * Clicking on a cell selects it.
-     */
-    onViewportClick(setSelection, giveFocus) {
-        setSelection(this.setAnchor());
-        //giveFocus();
-    }
-
-
     toJson() {
         return this.column()
                 .toJson() +

--- a/src/spreadsheet/reference/SpreadsheetCellReference.test.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.test.js
@@ -541,29 +541,6 @@ test("toRelative absolute2", () => {
     expect(SpreadsheetCellReference.parse("$C3").toRelative()).toEqual(SpreadsheetCellReference.parse("C3"));
 });
 
-// onViewportClick......................................................................................................
-
-test("onViewportClickAndTest cell=A1", () => {
-
-    const state = {
-        selection: SpreadsheetCellReference.parse("A1").toString(),
-        giveFormulaFocus: false,
-    };
-
-    const reference = SpreadsheetCellReference.parse("B2");
-
-    reference
-        .onViewportClick(
-            (s) => state.selection = s && s.toString(),
-            () => state.giveFormulaFocus = true,
-        );
-    expect(state)
-        .toStrictEqual({
-            selection: reference.setAnchor().toString(),
-            giveFormulaFocus: false,
-        });
-});
-
 // onViewportKeyDown....................................................................................................
 
 const SELECT_RANGE_FALSE = false;

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
@@ -129,13 +129,6 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
         return this;
     }
 
-    /**
-     * Clicking on a column or row selects it.
-     */
-    onViewportClick(setSelection, giveFormulaFocus) {
-        setSelection(this.setAnchor());
-    }
-
     selectOptionText() {
         return this.toString();
     }

--- a/src/spreadsheet/reference/SpreadsheetColumnReference.test.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReference.test.js
@@ -433,28 +433,6 @@ testRowAndCheck("A", "1", false);
 testRowAndCheck("B", "$2", false);
 testRowAndCheck("$C", "3", false);
 
-// onViewportClick......................................................................................................
-
-test("onViewportClickAndTest column=B", () => {
-
-    const state = {
-        selection: SpreadsheetCellReference.parse("Z99").toString(),
-    };
-
-    const reference = SpreadsheetColumnReference.parse("B");
-
-    reference
-        .onViewportClick(
-            (s) => state.selection = s && s.toString(),
-            () => {throw new Error("!")},
-            //SpreadsheetCellReference.parse("A1"),
-        );
-    expect(state)
-        .toStrictEqual({
-            selection: reference.setAnchor().toString(),
-        });
-});
-
 // onViewportKeyDown....................................................................................................
 
 const SELECT_RANGE_FALSE = false;

--- a/src/spreadsheet/reference/SpreadsheetRowReference.test.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReference.test.js
@@ -406,28 +406,6 @@ test("toJson RELATIVE", () => {
     expect(new SpreadsheetRowReference(3, SpreadsheetReferenceKind.RELATIVE).toJson()).toStrictEqual("4");
 });
 
-// onViewportClick......................................................................................................
-
-test("onViewportClickAndTest row=2", () => {
-
-    const state = {
-        selection: SpreadsheetCellReference.parse("Z99").toString(),
-    };
-
-    const reference = SpreadsheetRowReference.parse("2");
-
-    reference
-        .onViewportClick(
-            (s) => state.selection = s && s.toString(),
-            () => {throw new Error("!");},
-            ///SpreadsheetCellReference.parse("A1"),
-        );
-    expect(state)
-        .toStrictEqual({
-            selection: reference.toString(),
-        });
-});
-
 // onViewportKeyDown....................................................................................................
 
 const SELECT_RANGE_FALSE = false;

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -194,11 +194,4 @@ export default class SpreadsheetSelection extends SystemObject {
     toString() {
         return this.toJson();
     }
-
-    /**
-     * This function is called by the viewport widget when a click event happens.
-     */
-    onViewportClick(setSelection, giveFormulaFocus) {
-        SystemObject.throwUnsupportedOperation();
-    }
 }


### PR DESCRIPTION
… & clears action

- Previously each SpreadsheetSelection sub class had its own onViewportClick()