### PR TITLE
Settings integration tests: TWO_DIGIT_YEAR removed double date format…

### DIFF
--- a/cypress/integration/Settings.spec.js
+++ b/cypress/integration/Settings.spec.js
@@ -312,9 +312,6 @@ describe(
                         cy.get(dateParsePatternsId)
                             .type("{selectall}yy/mm/dd{enter}")
                             .blur();
-                        cy.get(dateFormatPatternId)
-                            .type("{selectall}yyyy/mm/dd{enter}")
-                            .blur();
 
                         cy.get(dateFormatPatternId)
                             .type("{selectall}yyyy/mm/dd{enter}")


### PR DESCRIPTION
… entry

- Doesnt fix broken tests only saves a bit of time.
- two digit year entry still broke because of too small two digit year number text box