### PR TITLE
Settings DEFAULT_YEAR uses SpreadsheetSettingsWidgetNumber.

### DIFF
--- a/cypress/integration/Settings.spec.js
+++ b/cypress/integration/Settings.spec.js
@@ -168,6 +168,22 @@ describe(
 
                 settingsOpenSectionSpreadsheetMetadataProperty(property);
 
+                const dateParsePatternsId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_PARSE_PATTERNS + "-TextField";
+                const dateFormatPatternId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_FORMAT_PATTERN + "-TextField";
+                switch(property) {
+                    case SpreadsheetMetadata.DEFAULT_YEAR:
+                        cy.get(dateParsePatternsId)
+                            .type("{selectall}dd:mm{enter}")
+                            .blur();
+
+                        cy.get(dateFormatPatternId)
+                            .type("{selectall}yyyy/mm/dd{enter}")
+                            .blur();
+                        break;
+                    default:
+                        break;
+                }
+
                 if(a1Formula){
                     testing.cellClick(A1);
 
@@ -299,15 +315,6 @@ describe(
                 const dateParsePatternsId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_PARSE_PATTERNS + "-TextField";
                 const dateFormatPatternId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_FORMAT_PATTERN + "-TextField";
                 switch(property) {
-                    case SpreadsheetMetadata.DEFAULT_YEAR:
-                        cy.get(dateParsePatternsId)
-                            .type("{selectall}dd:mm{enter}")
-                            .blur();
-
-                        cy.get(dateFormatPatternId)
-                            .type("{selectall}yyyy/mm/dd{enter}")
-                            .blur();
-                        break;
                     case SpreadsheetMetadata.TWO_DIGIT_YEAR:
                         cy.get(dateParsePatternsId)
                             .type("{selectall}yy/mm/dd{enter}")
@@ -490,20 +497,14 @@ describe(
             "2.5",
         );
 
-        settingsSpreadsheetMetadataPropertySliderNumberTextFieldAndCheck(
+        settingsSpreadsheetMetadataPropertyTextAndCheck(
             SpreadsheetMetadata.DEFAULT_YEAR,
             "31:12",
-            [
-                {
-                    value: "1900",
-                    text: "1900",
-                },
-                {
-                    value: "2000",
-                    text: "2000",
-                }
-            ],
-            ["1900/12/31", "2000/12/31"]
+            "2000",
+            "1900",
+            "31:12",
+            "2000/12/31",
+            "1900/12/31",
         );
 
         settingsSpreadsheetMetadataPropertyTextAndCheck(

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -26,6 +26,7 @@ import SpreadsheetMultiFormatResponse from "../server/format/SpreadsheetMultiFor
 import SpreadsheetSettingsWidgetCharacter from "./SpreadsheetSettingsWidgetCharacter.js";
 import SpreadsheetSettingsWidgetColor from "./SpreadsheetSettingsWidgetColor.js";
 import SpreadsheetSettingsWidgetDropDownList from "./SpreadsheetSettingsWidgetDropDownList.js";
+import SpreadsheetSettingsWidgetNumber from "./SpreadsheetSettingsWidgetNumber.js";
 import SpreadsheetSettingsWidgetSlider from "./SpreadsheetSettingsWidgetSlider.js";
 import SpreadsheetSettingsWidgetSliderWithNumberTextField
     from "./SpreadsheetSettingsWidgetSliderWithNumberTextField.js";
@@ -990,9 +991,41 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                                                           setValue={setValue}
                                 />;
                                 break;
+                            case SpreadsheetMetadata.DEFAULT_YEAR:
+                                var numberValue; // DATETIME_OFFSET is a java Long in String form, ugly hack to assume can always be converted to a number
+                                var min;
+                                var max;
+                                var style;
+                                switch(property) {
+                                    case SpreadsheetMetadata.DEFAULT_YEAR:
+                                        numberValue = value;
+                                        min = 0;
+                                        max = 2000;
+                                        style = {};
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                render = <SpreadsheetSettingsWidgetNumber id={id}
+                                                                          style={style}
+                                                                          min={min}
+                                                                          max={max}
+                                                                          value={numberValue}
+                                                                          defaultValue={typeof defaultValue === "string" ? parseInt(defaultValue, 10) : defaultValue}
+                                                                          defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}
+                                                                          defaultButtonTooltip={false}
+                                                                          setValue={setValue}
+                                />;
+                                break;
+
+
+
+
+
+
+
                             case SpreadsheetMetadata.CELL_CHARACTER_WIDTH:
                             case SpreadsheetMetadata.DATETIME_OFFSET:
-                            case SpreadsheetMetadata.DEFAULT_YEAR:
                             case SpreadsheetMetadata.PRECISION:
                             case SpreadsheetMetadata.TWO_DIGIT_YEAR:
                                 var numberValue; // DATETIME_OFFSET is a java Long in String form, ugly hack to assume can always be converted to a number
@@ -1038,26 +1071,6 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                             {
                                                 value: -24107,
                                                 label: "1904",
-                                            }
-                                        ];
-                                        step = null;
-                                        style = {
-                                            marginLeft: "1em",
-                                            marginRight: "2em",
-                                        };
-                                        break;
-                                    case SpreadsheetMetadata.DEFAULT_YEAR:
-                                        numberValue = value;
-                                        min = 1900;
-                                        max = 2020;
-                                        marks = [
-                                            {
-                                                value: 1900,
-                                                label: "1900",
-                                            },
-                                            {
-                                                value: 2000,
-                                                label: "2000",
                                             }
                                         ];
                                         step = null;

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetCharacter.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetCharacter.js
@@ -25,6 +25,10 @@ export default class SpreadsheetSettingsWidgetCharacter extends SpreadsheetSetti
         return 1;
     }
 
+    type() {
+        return "text";
+    }
+
     createValue(string) {
         var value;
 

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetColor.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetColor.js
@@ -26,6 +26,10 @@ export default class SpreadsheetSettingsWidgetColor extends SpreadsheetSettingsW
         return 7;
     }
 
+    type() {
+        return "text";
+    }
+
     createValue(string) {
         return (!!string ? Color.parse(string) : null);
     }

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetNumber.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetNumber.js
@@ -3,9 +3,9 @@ import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextF
 import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
 
 /**
- * A widget which displays a {@link String} for editing using a TextField. All edits immediately update the spreadsheet.
+ * A widget which displays a number for editing using a TextField. All edits immediately update the spreadsheet.
  */
-export default class SpreadsheetSettingsWidgetString extends SpreadsheetSettingsWidgetTextField {
+export default class SpreadsheetSettingsWidgetNumber extends SpreadsheetSettingsWidgetTextField {
 
     // eslint-disable-next-line
     constructor(props) {
@@ -17,7 +17,7 @@ export default class SpreadsheetSettingsWidgetString extends SpreadsheetSettings
     }
 
     size() {
-        return this.props.length;
+        return 1;
     }
 
     maxLength() {
@@ -25,15 +25,15 @@ export default class SpreadsheetSettingsWidgetString extends SpreadsheetSettings
     }
 
     type() {
-        return "text";
+        return "number";
     }
 
-    createValue(string) {
-        return string === "" ? undefined : string;
+    createValue(text) {
+        return parseInt(text, 10);
     }
 }
 
-SpreadsheetSettingsWidgetString.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
+SpreadsheetSettingsWidgetNumber.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
     PropTypes.string,
     {
         length: PropTypes.number.isRequired,

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextField.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextField.js
@@ -1,4 +1,4 @@
-import Keys from "../../Keys.js";
+ import Keys from "../../Keys.js";
 import React from 'react';
 import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
 import TextField from "@material-ui/core/TextField";
@@ -28,6 +28,7 @@ export default class SpreadsheetSettingsWidgetTextField extends SpreadsheetSetti
         const placeholder = this.placeholder();
         const size = this.size();
         const maxLength = this.maxLength();
+        const type = this.type();
 
         return <TextField inputRef={this.inputField}
                           id={textFieldId}
@@ -51,6 +52,7 @@ export default class SpreadsheetSettingsWidgetTextField extends SpreadsheetSetti
                               {
                                   size: size,
                                   maxLength: maxLength,
+                                  type: type,
                               }
                           }
                           onBlur={this.onBlur.bind(this)}
@@ -68,6 +70,13 @@ export default class SpreadsheetSettingsWidgetTextField extends SpreadsheetSetti
 
     maxLength() {
         throw new Error("Not yet implemented: maxLength");
+    }
+
+    /**
+     * This becomes the type=value of the INPUT field.
+     */
+    type() {
+        return "text";
     }
 
     /**


### PR DESCRIPTION
- Previously used slider with number text field which couldnt really fit in the settings panel.
- The small number text field also resulted in test failures because of failure to complete data entry.