### PR TITLE
Settings TWO_DIGIT_YEAR uses SpreadsheetSettingsWidgetNumber

### DIFF
--- a/cypress/integration/Settings.spec.js
+++ b/cypress/integration/Settings.spec.js
@@ -180,6 +180,15 @@ describe(
                             .type("{selectall}yyyy/mm/dd{enter}")
                             .blur();
                         break;
+                    case SpreadsheetMetadata.TWO_DIGIT_YEAR:
+                        cy.get(dateParsePatternsId)
+                            .type("{selectall}yy/mm/dd{enter}")
+                            .blur();
+
+                        cy.get(dateFormatPatternId)
+                            .type("{selectall}yyyy/mm/dd{enter}")
+                            .blur();
+                        break;
                     default:
                         break;
                 }
@@ -190,7 +199,7 @@ describe(
                     testing.formulaText()
                         .click()
                         .wait(FORMULA_TEXT_CLICK_WAIT)
-                        .type(a1Formula + "{enter}", FORCE_TRUE);
+                        .type("{selectall}" + a1Formula + "{enter}", FORCE_TRUE);
                 }
 
                 const textFieldId = "#settings-spreadsheet-metadata-" + property + "-TextField";
@@ -311,22 +320,6 @@ describe(
                 settingsToggle();
 
                 settingsOpenSectionSpreadsheetMetadataProperty(property);
-
-                const dateParsePatternsId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_PARSE_PATTERNS + "-TextField";
-                const dateFormatPatternId = "#settings-spreadsheet-metadata-" + SpreadsheetMetadata.DATE_FORMAT_PATTERN + "-TextField";
-                switch(property) {
-                    case SpreadsheetMetadata.TWO_DIGIT_YEAR:
-                        cy.get(dateParsePatternsId)
-                            .type("{selectall}yy/mm/dd{enter}")
-                            .blur();
-
-                        cy.get(dateFormatPatternId)
-                            .type("{selectall}yyyy/mm/dd{enter}")
-                            .blur();
-                        break;
-                    default:
-                        break;
-                }
 
                 if(a1Formula){
                     testing.cellClick(A1);
@@ -657,20 +650,14 @@ describe(
             "12:58:59",
         );
 
-        settingsSpreadsheetMetadataPropertySliderNumberTextFieldAndCheck(
+        settingsSpreadsheetMetadataPropertyTextAndCheck(
             SpreadsheetMetadata.TWO_DIGIT_YEAR,
             "30/12/31",
-            [
-                {
-                    value: "20",
-                    text: "20",
-                },
-                {
-                    value: "50",
-                    text: "50",
-                },
-            ],
-            ["1930/12/31", "2030/12/31"]
+            "50",
+            "20",
+            "30/12/31",
+            "2030/12/31",
+            "1930/12/31",
         );
 
         settingsSpreadsheetMetadataPropertyTextAndCheck(
@@ -772,7 +759,7 @@ describe(
                 const textFieldId = "#settings-spreadsheet-metadata-style-" + property + "-TextField";
 
                 cy.get(textFieldId)
-                    .type("{selectall}!invalid123")
+                    .type("{selectall}!BAD")
                     .blur(); // TODO verify alert appears!
 
                 cy.get(textFieldId)

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -992,6 +992,7 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                 />;
                                 break;
                             case SpreadsheetMetadata.DEFAULT_YEAR:
+                            case SpreadsheetMetadata.TWO_DIGIT_YEAR:
                                 var numberValue; // DATETIME_OFFSET is a java Long in String form, ugly hack to assume can always be converted to a number
                                 var min;
                                 var max;
@@ -1001,6 +1002,12 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                         numberValue = value;
                                         min = 0;
                                         max = 2000;
+                                        style = {};
+                                        break;
+                                    case SpreadsheetMetadata.TWO_DIGIT_YEAR:
+                                        numberValue = value;
+                                        min = 0;
+                                        max = 99;
                                         style = {};
                                         break;
                                     default:
@@ -1017,17 +1024,9 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                                                           setValue={setValue}
                                 />;
                                 break;
-
-
-
-
-
-
-
                             case SpreadsheetMetadata.CELL_CHARACTER_WIDTH:
                             case SpreadsheetMetadata.DATETIME_OFFSET:
                             case SpreadsheetMetadata.PRECISION:
-                            case SpreadsheetMetadata.TWO_DIGIT_YEAR:
                                 var numberValue; // DATETIME_OFFSET is a java Long in String form, ugly hack to assume can always be converted to a number
                                 var min;
                                 var max;
@@ -1099,30 +1098,6 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                                             {
                                                 value: 128,
                                                 label: "128",
-                                            },
-                                        ];
-                                        step = null;
-                                        style = {
-                                            marginLeft: "2em",
-                                            marginRight: "2em",
-                                        };
-                                        break;
-                                    case SpreadsheetMetadata.TWO_DIGIT_YEAR:
-                                        numberValue = value;
-                                        min = 0;
-                                        max = 99;
-                                        marks = [
-                                            {
-                                                value: 20,
-                                                label: "20",
-                                            },
-                                            {
-                                                value: 50,
-                                                label: "50",
-                                            },
-                                            {
-                                                value: 70,
-                                                label: "70",
                                             },
                                         ];
                                         step = null;


### PR DESCRIPTION
- Only outstanding broken tests are border-width because browser returns 1.333px when expecting 1px