### PR TITLE
SpreadsheetSettingWidgetCharacter swap UI value fix

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -982,7 +982,7 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
                             case SpreadsheetMetadata.POSITIVE_SIGN:
                             case SpreadsheetMetadata.VALUE_SEPARATOR:
                                 render = <SpreadsheetSettingsWidgetCharacter id={id}
-                                                                             key={id}
+                                                                             key={[id, value, defaultValue]}
                                                                              value={value}
                                                                              defaultValue={defaultValue}
                                                                              defaultValueFormatter={DEFAULT_VALUE_FORMATTER_TOSTRING}


### PR DESCRIPTION
- Any character property that should also swap and update another character property now fixed.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1430
- Settings: property swap not updating other property UI