### PR TITLE
Settings textfield slider absent value improvements

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -1246,7 +1246,7 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
      * Factory that creates a slider with number using the property to customized some properties.
      */
     sliderAndNumber(property, value, id, defaultValue, setValue) {
-        const numberValue = Number.isNaN(Number(value)) ? 0 : value;
+        const numberValue = Number.isNaN(Number(value)) ? null : value;
         var min;
         var max;
         var marks;


### PR DESCRIPTION
- Previously cell-character-width, date-time offset, precision converted absent values to 0, updated to empty string.