### PR TITLE
SpreadsheetHistoryHash.onHistoryChange use event newUrl 2/2

### DIFF
--- a/cypress/integration/LabelMapping.spec.js
+++ b/cypress/integration/LabelMapping.spec.js
@@ -362,10 +362,14 @@ describe(
             testing.labelMappingLabelSaveButton()
                 .click();
 
+            testing.historyWait();
+
             testing.hashLabel();
 
             testing.labelMappingLabelDeleteButton()
                 .click();
+
+            testing.historyWait();
 
             testing.hashLabel();
 

--- a/cypress/integration/SpreadsheetTesting.js
+++ b/cypress/integration/SpreadsheetTesting.js
@@ -171,6 +171,8 @@ export default class SpreadsheetTesting {
 
     hashLabel() {
         this.hashAppend("/label/" + SpreadsheetTesting.LABEL);
+
+        this.historyWait();
     }
 
     selectHistoryHash() {


### PR DESCRIPTION
- SpreadsheetHistoryHash removed caching.
- SpreadsheetHistoryAwareWidget.historyParseMergeAndPush fires SetTimeout