### PR TITLE
SpreadsheetMetadata.viewportEquals

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -399,7 +399,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                     }
 
                     // some metadata properties changed that will mean formatting of values changed so reload
-                    if(metadata.shouldUpdateViewport(previousMetadata)){
+                    if(!metadata.viewportEquals(previousMetadata)){
                         console.log("Metadata change need to format all viewport cells", metadata);
                         viewportLoadCells = true;
                         break;

--- a/src/spreadsheet/meta/SpreadsheetMetadata.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.js
@@ -777,10 +777,10 @@ export default class SpreadsheetMetadata extends SystemObject {
     }
 
     /**
-     * Returns true if any of the #VIEWPORT_SHOULD_UPDATE_PROPERTY_NAMES properties are different.
+     * Returns true if any of the #VIEWPORT_EQUALS_PROPERTY_NAMES properties are different.
      */
-    shouldUpdateViewport(other) {
-        return !equals0(this, other, VIEWPORT_SHOULD_UPDATE_PROPERTY_NAMES);
+    viewportEquals(other) {
+        return equals0(this, other, VIEWPORT_EQUALS_PROPERTY_NAMES);
     }
 
     toString() {
@@ -832,8 +832,9 @@ const PROPERTY_NAMES = [
 /**
  * Used when comparing two metadata ignoring a few properties that are unimportant when deciding if a viewport cells should be reloaded.
  */
-const VIEWPORT_SHOULD_UPDATE_PROPERTY_NAMES = PROPERTY_NAMES.filter(p => {
+const VIEWPORT_EQUALS_PROPERTY_NAMES = PROPERTY_NAMES.filter(p => {
     var keep;
+
     switch(p) {
         case SpreadsheetMetadata.CREATOR:
         case SpreadsheetMetadata.CREATE_DATE_TIME:
@@ -841,7 +842,6 @@ const VIEWPORT_SHOULD_UPDATE_PROPERTY_NAMES = PROPERTY_NAMES.filter(p => {
         case SpreadsheetMetadata.MODIFIED_DATE_TIME:
         case SpreadsheetMetadata.SELECTION:
         case SpreadsheetMetadata.SPREADSHEET_NAME:
-        case SpreadsheetMetadata.VIEWPORT_CELL:
             keep = false;
             break;
         default:
@@ -864,7 +864,7 @@ function equals1(metadata, other, required) {
     const otherProperties = other.properties;
 
     // if required === IGNORED_PROPERTIES must test all individual properties...
-    if(required === VIEWPORT_SHOULD_UPDATE_PROPERTY_NAMES || Object.keys(properties).length === Object.keys(otherProperties).length){
+    if(required === VIEWPORT_EQUALS_PROPERTY_NAMES || Object.keys(properties).length === Object.keys(otherProperties).length){
         equals = true;
 
         for(const property of required) {

--- a/src/spreadsheet/meta/SpreadsheetMetadata.test.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadata.test.js
@@ -1105,179 +1105,140 @@ test("equals same property values with defaults", () => {
     ))).toEqual(true);
 });
 
-// shouldUpdateViewport...............................................................................................................
+// viewportEquals.......................................................................................................
 
-test("shouldUpdateViewport missing true", () => {
-    expect(SpreadsheetMetadata.EMPTY.shouldUpdateViewport(undefined))
-        .toBeTrue();
-});
+function testViewportEquals(titleSuffix, left, right, result) {
+    test("viewportEquals " + titleSuffix + " " + result, () => {
+        expect(SpreadsheetMetadata.fromJson(left)
+            .viewportEquals(SpreadsheetMetadata.fromJson(right))
+        ).toBe(result);
+    });
+}
 
-test("shouldUpdateViewport EMPTY true", () => {
-    expect(SpreadsheetMetadata.EMPTY.shouldUpdateViewport(SpreadsheetMetadata.EMPTY))
-        .toBeFalse();
-});
+testViewportEquals(
+    "id different",
+    {
+        "spreadsheet-id": "123",
+    },
+    {
+        "spreadsheet-id": "456",
+    },
+    false
+);
 
-test("shouldUpdateViewport same ignoring ignored properties", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "create-date-time": "123",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "create-date-time": "456",
-        }
-    ))).toBeFalse();
-});
+testViewportEquals(
+    "id same",
+    {
+        "spreadsheet-id": "123",
+    },
+    {
+        "spreadsheet-id": "123",
+    },
+    true
+);
 
-test("shouldUpdateViewport different ids", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "123",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "456",
-        }
-    ))).toBeTrue();
-});
+testViewportEquals(
+    "id & name same",
+    {
+        "spreadsheet-id": "123",
+        "spreadsheet-name": "SpreadsheetName456",
+    },
+    {
+        "spreadsheet-id": "123",
+        "spreadsheet-name": "SpreadsheetName456",
+    },
+    true
+);
 
-test("shouldUpdateViewport property values different true", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "NZD",
-        }
-    ))).toBeTrue();
-});
+testViewportEquals(
+    "id & name different",
+    {
+        "spreadsheet-id": "123",
+        "spreadsheet-name": "SpreadsheetName456",
+    },
+    {
+        "spreadsheet-id": "123",
+        "spreadsheet-name": "SpreadsheetName999",
+    },
+    true
+);
 
-test("shouldUpdateViewport property values different true #2", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": "D",
-        }
-    ))).toBeTrue();
-});
+testViewportEquals(
+    "id & name different",
+    {
+        "spreadsheet-id": "123",
+        "spreadsheet-name": "SpreadsheetName456",
+    },
+    {
+        "spreadsheet-id": "456",
+        "spreadsheet-name": "SpreadsheetName999",
+    },
+    false
+);
 
-test("shouldUpdateViewport property values different " + SpreadsheetMetadata.SELECTION, () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-            "selection": SpreadsheetCellReference.parse("A1").setAnchor().toJson(),
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-            "selection": SpreadsheetCellReference.parse("Z99").setAnchor().toJson(),
-        }
-    ))).toBeFalse();
-});
+testViewportEquals(
+    "currency different",
+    {
+        "spreadsheet-id": "123",
+        "currency-symbol": "$AUD",
+    },
+    {
+        "spreadsheet-id": "123",
+        "currency-symbol": "Different",
+    },
+    false
+);
 
-test("shouldUpdateViewport property values different " + SpreadsheetMetadata.VIEWPORT_CELL, () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "viewport-cell": "A1",
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "viewport-cell": "Z99",
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-        }
-    ))).toBeFalse();
-});
+testViewportEquals(
+    "currency different 2",
+    {
+        "spreadsheet-id": "123",
+        "currency-symbol": "$AUD",
+    },
+    {
+        "spreadsheet-id": "123",
+    },
+    false
+);
 
-test("shouldUpdateViewport property values", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "currency-symbol": "AUD",
-            "decimal-separator": ".",
-        }
-    ))).toBeFalse();
-});
+testViewportEquals(
+    "currency same",
+    {
+        "spreadsheet-id": "123",
+        "currency-symbol": "$AUD",
+    },
+    {
+        "spreadsheet-id": "123",
+        "currency-symbol": "$AUD",
+    },
+    true
+);
 
-test("shouldUpdateViewport with defaults", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "111",
-            "currency-symbol": "AUD",
-            "_defaults": {
-                "decimal-separator": ".",
-                "spreadsheet-name": "Spreadsheet-name-567",
-            }
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "111",
-            "currency-symbol": "AUD",
-            "_defaults": {
-                "decimal-separator": ".",
-                "spreadsheet-name": "Spreadsheet-name-567",
-            }
-        }
-    ))).toBeFalse();
-});
+testViewportEquals(
+    "different selection",
+    {
+        "spreadsheet-id": "123",
+        "selection": SpreadsheetCellReference.parse("A1").setAnchor().toJson(),
+    },
+    {
+        "spreadsheet-id": "123",
+        "selection": SpreadsheetCellReference.parse("B2").setAnchor().toJson(),
+    },
+    true
+);
 
-test("shouldUpdateViewport with defaults different", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "111",
-            "currency-symbol": "AUD",
-            "_defaults": {
-                "decimal-separator": ".",
-                "spreadsheet-name": "Spreadsheet-name-567",
-            }
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "222",
-            "currency-symbol": "NZD",
-            "_defaults": {
-                "decimal-separator": ".",
-                "spreadsheet-name": "different-Spreadsheet-name",
-            }
-        }
-    ))).toBeTrue();
-});
-
-test("shouldUpdateViewport with defaults different default", () => {
-    expect(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "111",
-            "currency-symbol": "AUD",
-            "_defaults": {
-                "decimal-separator": ".",
-                "spreadsheet-name": "Spreadsheet-name-567",
-            }
-        }
-    ).shouldUpdateViewport(SpreadsheetMetadata.fromJson(
-        {
-            "spreadsheet-id": "111",
-            "currency-symbol": "NZD",
-            "_defaults": {
-                "decimal-separator": "D",
-                "spreadsheet-name": "different-Spreadsheet-name",
-            }
-        }
-    ))).toBeTrue();
-});
+testViewportEquals(
+    "different viewport-cell",
+    {
+        "spreadsheet-id": "123",
+        "viewport-cell": SpreadsheetCellReference.parse("A1").toJson(),
+    },
+    {
+        "spreadsheet-id": "123",
+        "viewport-cell": SpreadsheetCellReference.parse("B2").toJson(),
+    },
+    false
+);
 
 // helpers..............................................................................................................
 


### PR DESCRIPTION
- replaces SpreadsheetMetadata.shouldViewportUpdate
- now includes viewport-cell, previously ignored during test.