### PR TITLE
SpreadsheetSettingsWidget: history-hash-token accordion, property & s…

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetHistoryHashTokens.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetHistoryHashTokens.js
@@ -1,0 +1,152 @@
+import SpreadsheetMetadata from "../meta/SpreadsheetMetadata.js";
+import TextStyle from "../../text/TextStyle.js";
+
+/**
+ * Helpers required by SpreadsheetSettingsWidget and SpreadsheetHistoryHash extracted to avoid cycles between classes.
+ */
+export default class SpreadsheetSettingsWidgetHistoryHashTokens {
+
+    // these tokens are optional and only one may appear after SETTINGS
+    static METADATA = "metadata";
+    static TEXT = "text";
+    static NUMBER = "number";
+    static DATE_TIME = "date-time";
+    static STYLE = "style";
+
+    static accordions() {
+        return [
+            SpreadsheetSettingsWidgetHistoryHashTokens.METADATA,
+            SpreadsheetSettingsWidgetHistoryHashTokens.TEXT,
+            SpreadsheetSettingsWidgetHistoryHashTokens.NUMBER,
+            SpreadsheetSettingsWidgetHistoryHashTokens.DATE_TIME,
+            SpreadsheetSettingsWidgetHistoryHashTokens.STYLE
+        ];
+    }
+
+    /**
+     * Returns the settings accordion name for the given property or null if not found.
+     */
+    static parentAccordion(property) {
+        var parentAccordion;
+
+        do {
+            if(SpreadsheetSettingsWidgetHistoryHashTokens.metadataRows().includes(property)){
+                parentAccordion = SpreadsheetSettingsWidgetHistoryHashTokens.METADATA;
+                break;
+            }
+            if(SpreadsheetSettingsWidgetHistoryHashTokens.spreadsheetTextRows().includes(property)){
+                parentAccordion = SpreadsheetSettingsWidgetHistoryHashTokens.TEXT;
+                break;
+            }
+            if(SpreadsheetSettingsWidgetHistoryHashTokens.spreadsheetDateTimeRows().includes(property)){
+                parentAccordion = SpreadsheetSettingsWidgetHistoryHashTokens.DATE_TIME;
+                break;
+            }
+            if(SpreadsheetSettingsWidgetHistoryHashTokens.spreadsheetNumberRows().includes(property)){
+                parentAccordion = SpreadsheetSettingsWidgetHistoryHashTokens.NUMBER;
+                break;
+            }
+            if(SpreadsheetSettingsWidgetHistoryHashTokens.spreadsheetStyleRows().includes(property)){
+                parentAccordion = SpreadsheetSettingsWidgetHistoryHashTokens.STYLE;
+                break;
+            }
+        } while(false);
+
+        return parentAccordion;
+    }
+
+    static metadataRows() {
+        return [
+            SpreadsheetMetadata.SPREADSHEET_ID,
+            SpreadsheetMetadata.CREATOR,
+            SpreadsheetMetadata.CREATE_DATE_TIME,
+            SpreadsheetMetadata.MODIFIED_BY,
+            SpreadsheetMetadata.MODIFIED_DATE_TIME,
+        ];
+    }
+
+    static spreadsheetTextRows() {
+        return [
+            TextStyle.COLOR,
+            //TextStyle.DIRECTION,
+            //TextStyle.FONT_FAMILY,
+            //TextStyle.FONT_SIZE,
+            //TextStyle.FONT_STYLE,
+            //TextStyle.FONT_VARIANT,
+            //TextStyle.FONT_WEIGHT,
+            TextStyle.TEXT_ALIGN,
+            TextStyle.HYPHENS,
+            //TextStyle.LINE_HEIGHT,
+            TextStyle.VERTICAL_ALIGN,
+            //TextStyle.WORD_SPACING,
+            TextStyle.WORD_BREAK,
+            TextStyle.WORD_WRAP,
+            //
+            SpreadsheetMetadata.LOCALE,
+            SpreadsheetMetadata.TEXT_FORMAT_PATTERN,
+            SpreadsheetMetadata.CELL_CHARACTER_WIDTH,
+        ];
+    }
+
+    static spreadsheetDateTimeRows() {
+        return [
+            SpreadsheetMetadata.DATETIME_OFFSET,
+            SpreadsheetMetadata.DEFAULT_YEAR,
+            SpreadsheetMetadata.TWO_DIGIT_YEAR,
+            SpreadsheetMetadata.DATE_FORMAT_PATTERN,
+            SpreadsheetMetadata.DATE_PARSE_PATTERNS,
+            SpreadsheetMetadata.DATETIME_FORMAT_PATTERN,
+            SpreadsheetMetadata.DATETIME_PARSE_PATTERNS,
+            SpreadsheetMetadata.TIME_FORMAT_PATTERN,
+            SpreadsheetMetadata.TIME_PARSE_PATTERNS
+        ];
+    }
+
+    static spreadsheetNumberRows() {
+        return [
+            SpreadsheetMetadata.EXPRESSION_NUMBER_KIND,
+            SpreadsheetMetadata.PRECISION,
+            SpreadsheetMetadata.ROUNDING_MODE,
+            SpreadsheetMetadata.CURRENCY_SYMBOL,
+            SpreadsheetMetadata.DECIMAL_SEPARATOR,
+            SpreadsheetMetadata.EXPONENT_SYMBOL,
+            SpreadsheetMetadata.GROUPING_SEPARATOR,
+            SpreadsheetMetadata.NEGATIVE_SIGN,
+            SpreadsheetMetadata.PERCENTAGE_SYMBOL,
+            SpreadsheetMetadata.POSITIVE_SIGN,
+            SpreadsheetMetadata.NUMBER_FORMAT_PATTERN,
+            SpreadsheetMetadata.NUMBER_PARSE_PATTERNS,
+            SpreadsheetMetadata.VALUE_SEPARATOR,
+        ];
+    }
+
+    static spreadsheetStyleRows() {
+        return [
+            TextStyle.BACKGROUND_COLOR,
+            //
+            TextStyle.WIDTH,
+            TextStyle.HEIGHT,
+            //
+            TextStyle.BORDER_LEFT_COLOR,
+            TextStyle.BORDER_LEFT_STYLE,
+            TextStyle.BORDER_LEFT_WIDTH,
+            //
+            TextStyle.BORDER_TOP_COLOR,
+            TextStyle.BORDER_TOP_STYLE,
+            TextStyle.BORDER_TOP_WIDTH,
+            //
+            TextStyle.BORDER_RIGHT_COLOR,
+            TextStyle.BORDER_RIGHT_STYLE,
+            TextStyle.BORDER_RIGHT_WIDTH,
+            //
+            TextStyle.BORDER_BOTTOM_COLOR,
+            TextStyle.BORDER_BOTTOM_STYLE,
+            TextStyle.BORDER_BOTTOM_WIDTH,
+            //
+            TextStyle.PADDING_LEFT,
+            TextStyle.PADDING_TOP,
+            TextStyle.PADDING_RIGHT,
+            TextStyle.PADDING_BOTTOM,
+        ];
+    }
+}

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetSliderAndTextField.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetSliderAndTextField.js
@@ -1,0 +1,114 @@
+import Keys from "../../Keys.js";
+import PropTypes from "prop-types";
+import React from 'react';
+import Slider from "@material-ui/core/Slider";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+import TextField from "@material-ui/core/TextField";
+
+/**
+ * Shows a slider that allows editing of a number including min/max support and translation to a similar number value
+ * such as Length.
+ */
+export default class SpreadsheetSettingsWidgetSliderAndTextField extends SpreadsheetSettingsWidgetValue {
+
+    constructor(props) {
+        super(props);
+
+        this.textFieldRef = React.createRef();
+    }
+
+    focus() {
+        this.giveFocus(this.textFieldRef.current);
+    }
+
+    renderValue(id, value) {
+        const sliderId = id + "-Slider";
+        const numberTextFieldId = id + "-NumberTextField";
+
+        const props = this.props;
+        const {valueToNumber, min, max, marks, step, style} = props;
+
+        const numericValue = valueToNumber(value);
+
+        return [
+            <TextField id={numberTextFieldId}
+                       key={numberTextFieldId}
+                       ref={this.textFieldRef}
+                       style={
+                           {
+                               marginRight: "4px",
+                               width: "100px",
+                           }
+                       }
+                       margin="none"
+                       disabled={false}
+                       InputLabelProps={
+                           {
+                               shrink: true,
+                               tabIndex: 0,
+                           }
+                       }
+                       value={numericValue != null ? String(numericValue) : ""}
+                       inputProps={
+                           {
+                               min: min,
+                               max: max,
+                               type: "number",
+                               maxLength: 2,
+                           }
+                       }
+                       onChange={(e) => {
+                           const value = e.target.value;
+                           this.onChangeNumber("" === value ? null : parseInt(value, 10));
+                       }}
+                       onKeyDown={this.onKeyDown.bind(this)}
+            />,
+            <Slider id={sliderId}
+                    key={[sliderId, value]} // key requires value to force re-rendering.
+                    min={min}
+                    max={max}
+                    step={step}
+                    marks={marks}
+                    value={numericValue}
+                    onChange={(e, newValue) => this.onChangeNumber(newValue)}
+                    style={style}/>,
+        ];
+    }
+
+    onChangeNumber(number) {
+        const props = this.props;
+        const value = props.numberToValue(number);
+
+        console.log(this.prefix() + ".onChangeNumber " + props.property + " number=" + number + ", value=" + value);
+        this.setState({
+            value: value,
+        });
+    }
+
+    /**
+     * Watches out for ESCAPE and reloads the last saved value.
+     */
+    onKeyDown(e) {
+        switch(e.key) {
+            case Keys.ESCAPE:
+                this.setState({
+                    value: this.state.savedValue,
+                });
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+SpreadsheetSettingsWidgetSliderAndTextField.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
+    PropTypes.number,
+    {
+        min: PropTypes.number.isRequired,
+        max: PropTypes.number.isRequired,
+        marks: PropTypes.array.isRequired,
+        step: PropTypes.number, // null is acceptable
+        numberToValue: PropTypes.func.isRequired, // happens before a save Metadata
+        valueToNumber: PropTypes.func.isRequired, // converts a value to a number.
+    }
+);

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldCharacter.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldCharacter.js
@@ -1,0 +1,41 @@
+import Character from "../../Character.js";
+import PropTypes from "prop-types";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which displays a {@link Character} for editing using a TextField. All edits immediately update the spreadsheet.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldCharacter extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter 1 character";
+    }
+
+    size() {
+        return 1;
+    }
+
+    maxLength() {
+        return 1;
+    }
+
+    type() {
+        return "text";
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                break;
+            default:
+                value = Character.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldCharacter.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(Character));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldColor.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldColor.js
@@ -1,0 +1,42 @@
+import Color from "../../color/Color.js";
+import PropTypes from "prop-types";
+import SpreadsheetNotification from "../notification/SpreadsheetNotification.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget that displays a TextField and creates a Color from any entered text.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldColor extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "#rrggbb";
+    }
+
+    size() {
+        return 7;
+    }
+
+    maxLength() {
+        return 7;
+    }
+
+    type() {
+        return "text";
+    }
+
+    stringToValue(string) {
+        return (!!string ? Color.parse(string) : null);
+    }
+
+    onError(text, errorMessage) {
+        this.props.notificationShow(SpreadsheetNotification.error("Invalid color \"" + text + "\""));
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldColor.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
+    PropTypes.instanceOf(Color),
+    {
+        notificationShow: PropTypes.func.isRequired
+    }
+);

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldNumber.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldNumber.js
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which displays a number for editing using a TextField. All edits immediately update the spreadsheet.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldNumber extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return;
+    }
+
+    size() {
+        return 1;
+    }
+
+    maxLength() {
+        return this.props.maxLength;
+    }
+
+    type() {
+        return "number";
+    }
+
+    stringToValue(text) {
+        return parseInt(text, 10);
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldNumber.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
+    PropTypes.number,
+    {
+        length: PropTypes.number.isRequired,
+        maxLength: PropTypes.number.isRequired,
+    }
+);

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateFormatPattern.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateFormatPattern.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetDateFormatPattern from "../format/SpreadsheetDateFormatPattern.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetDateFormatPattern}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetDateFormatPattern extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetDateFormatPattern.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetDateFormatPattern.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetDateFormatPattern));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateParsePatterns.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateParsePatterns.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetDateParsePatterns from "../format/SpreadsheetDateParsePatterns.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetDateParsePatterns}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetDateParsePatterns extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetDateParsePatterns.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetDateParsePatterns.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetDateParsePatterns));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeFormatPattern.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeFormatPattern.js
@@ -1,0 +1,43 @@
+import PropTypes from "prop-types";
+import SpreadsheetDateTimeFormatPattern from "../format/SpreadsheetDateTimeFormatPattern.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetDateTimeFormatPattern}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeFormatPattern extends SpreadsheetSettingsWidgetTextField {
+
+    // eslint-disable-next-line
+    constructor(props) {
+        super(props);
+    }
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetDateTimeFormatPattern.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeFormatPattern.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetDateTimeFormatPattern));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeParsePatterns.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeParsePatterns.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetDateTimeParsePatterns from "../format/SpreadsheetDateTimeParsePatterns.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetDateTimeParsePatterns}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeParsePatterns extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetDateTimeParsePatterns.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetDateTimeParsePatterns.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetDateTimeParsePatterns));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberFormatPattern.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberFormatPattern.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetNumberFormatPattern from "../format/SpreadsheetNumberFormatPattern.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetNumberFormatPattern}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberFormatPattern extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetNumberFormatPattern.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberFormatPattern.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetNumberFormatPattern));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberParsePatterns.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberParsePatterns.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetNumberParsePatterns from "../format/SpreadsheetNumberParsePatterns.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetNumberParsePatterns}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberParsePatterns extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetNumberParsePatterns.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetNumberParsePatterns.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetNumberParsePatterns));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTextFormatPattern.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTextFormatPattern.js
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+import SpreadsheetTextFormatPattern from "../format/SpreadsheetTextFormatPattern.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetTextFormatPattern}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetTextFormatPattern extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                break;
+            default:
+                value = SpreadsheetTextFormatPattern.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetTextFormatPattern.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetTextFormatPattern));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeFormatPattern.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeFormatPattern.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetTimeFormatPattern from "../format/SpreadsheetTimeFormatPattern.js";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetTimeFormatPattern}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeFormatPattern extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetTimeFormatPattern.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeFormatPattern.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetTimeFormatPattern));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeParsePatterns.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeParsePatterns.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+import SpreadsheetTimeParsePatterns from "../format/SpreadsheetTimeParsePatterns.js";
+
+/**
+ * A widget which accepts a String and creates an unvalidated {@link SpreadsheetTimeParsePatterns}.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeParsePatterns extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return "Enter pattern";
+    }
+
+    size() {
+        return 20;
+    }
+
+    maxLength() {
+        return 255;
+    }
+
+    stringToValue(string) {
+        var value;
+
+        switch(string.length) {
+            case 0:
+                value = null;
+                break;
+            default:
+                value = SpreadsheetTimeParsePatterns.fromJson(string);
+                break;
+        }
+        return value;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldSpreadsheetTimeParsePatterns.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(PropTypes.instanceOf(SpreadsheetTimeParsePatterns));

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldString.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidgetTextFieldString.js
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+import SpreadsheetSettingsWidgetTextField from "./SpreadsheetSettingsWidgetTextField.js";
+import SpreadsheetSettingsWidgetValue from "./SpreadsheetSettingsWidgetValue.js";
+
+/**
+ * A widget which displays a {@link String} for editing using a TextField. All edits immediately update the spreadsheet.
+ */
+export default class SpreadsheetSettingsWidgetTextFieldString extends SpreadsheetSettingsWidgetTextField {
+
+    placeholder() {
+        return;
+    }
+
+    size() {
+        return this.props.length;
+    }
+
+    maxLength() {
+        return this.props.maxLength;
+    }
+
+    type() {
+        return "text";
+    }
+
+    stringToValue(string) {
+        return string === "" ? undefined : string;
+    }
+}
+
+SpreadsheetSettingsWidgetTextFieldString.propTypes = SpreadsheetSettingsWidgetValue.createPropTypes(
+    PropTypes.string,
+    {
+        length: PropTypes.number.isRequired,
+        maxLength: PropTypes.number.isRequired,
+    }
+);


### PR DESCRIPTION
…aving support 2/2

- settings drawer given focus when opened
- history hash support for individual properties.
- hash save property support.
- renamed (shortened) SpreadsheetSettingsWidget method names.
- updated all SpreadsheetSettingsWidgetValue sub classes to be controlled (previously some were mixed).
- internal refactoring / naming improvements of SpreadsheetSettingsWidgetValue and sub classes.
- TODO Improve reliability of tabbing tests, spurious history hash events interrupt flow.