### PR TITLE
Settings-icon link replaces menu click listener

### DIFF
--- a/src/spreadsheet/SpreadsheetApp.js
+++ b/src/spreadsheet/SpreadsheetApp.js
@@ -13,6 +13,7 @@ import SpreadsheetDelta from "./engine/SpreadsheetDelta.js";
 import SpreadsheetEngineEvaluation from "./engine/SpreadsheetEngineEvaluation.js";
 import SpreadsheetExpressionReferenceSimilarities from "./SpreadsheetExpressionReferenceSimilarities.js";
 import SpreadsheetFormulaWidget from "./SpreadsheetFormulaWidget.js";
+import SpreadsheetHistoryHash from "./history/SpreadsheetHistoryHash.js";
 import SpreadsheetHistoryAwareStateWidget from "./history/SpreadsheetHistoryAwareStateWidget.js";
 import SpreadsheetHistoryHashTokens from "./history/SpreadsheetHistoryHashTokens.js";
 import SpreadsheetLabelMapping from "./reference/SpreadsheetLabelMapping.js";
@@ -28,7 +29,6 @@ import SpreadsheetSelectLinkWidget from "./reference/SpreadsheetSelectLinkWidget
 import SpreadsheetSettingsWidget from "./settings/SpreadsheetSettingsWidget.js";
 import SpreadsheetViewportWidget from "./SpreadsheetViewportWidget.js";
 import WindowResizer from "../widget/WindowResizer.js";
-import SpreadsheetHistoryHash from "./history/SpreadsheetHistoryHash.js";
 
 const useStyles = theme => ({
     header: {
@@ -288,7 +288,8 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
                                 dimensions={this.onAboveViewportResize.bind(this)}
                                 className={classes.header}
                 >
-                    <SpreadsheetAppBar menuClickListener={this.settingsToggle.bind(this)}>
+                    <SpreadsheetAppBar key={"AppBar"}
+                                       history={history}>
                         <SpreadsheetNameWidget key={"SpreadsheetName"}
                                                history={history}
                                                spreadsheetMetadataCrud={spreadsheetMetadataCrud}
@@ -405,12 +406,6 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
             response,
             error || this.props.showError,
         )
-    }
-
-    // settings.........................................................................................................
-
-    settingsToggle() {
-        this.props.history.settingsToggle();
     }
 
     // similarities.....................................................................................................

--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -90,7 +90,7 @@ const useStyles = theme => ({
 /**
  * Debug option that when false means the drawer will not close when it loses focus to something outside.
  */
-const BLUR_CLOSES_DRAWER = true;
+const BLUR_CLOSES_DRAWER = false;
 
 class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
 

--- a/src/widget/SpreadsheetAppBar.js
+++ b/src/widget/SpreadsheetAppBar.js
@@ -4,12 +4,20 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import PropTypes from "prop-types";
 import React from 'react';
+import SpreadsheetHistoryAwareStateWidget from "../spreadsheet/history/SpreadsheetHistoryAwareStateWidget.js";
+import SpreadsheetHistoryHash from "../spreadsheet/history/SpreadsheetHistoryHash.js";
+import SpreadsheetHistoryHashTokens from "../spreadsheet/history/SpreadsheetHistoryHashTokens.js";
 import Toolbar from '@mui/material/Toolbar';
+
+function computeSettingsLink(historyHashTokens) {
+    historyHashTokens[SpreadsheetHistoryHashTokens.SETTINGS] = !(historyHashTokens[SpreadsheetHistoryHashTokens.SETTINGS]);
+    return "#" + SpreadsheetHistoryHash.stringify(historyHashTokens);
+}
 
 /**
  * An header that displays a menu, followed by an any children which will include the spreadsheet name.
  */
-export default class SpreadsheetAppBar extends React.Component {
+export default class SpreadsheetAppBar extends SpreadsheetHistoryAwareStateWidget {
 
     static classes = makeStyles((theme) => ({
         root: {
@@ -23,9 +31,29 @@ export default class SpreadsheetAppBar extends React.Component {
         },
     }));
 
-    constructor(props) {
-        super(props);
-        this.menuClickListener = props.menuClickListener;
+    init() {
+    }
+
+    initialStateFromProps(props) {
+        return {
+            settingsLink: computeSettingsLink(props.history.tokens())
+        };
+    }
+
+    /**
+     * Re-compute the settings link url.
+     */
+    stateFromHistoryTokens(historyHashTokens) {
+        return {
+            settingsLink: computeSettingsLink(historyHashTokens)
+        };
+    }
+
+    /**
+     * Never updates the history tokens.
+     */
+    historyTokensFromState(prevState) {
+        return SpreadsheetHistoryHashTokens.emptyTokens();
     }
 
     render() {
@@ -36,7 +64,7 @@ export default class SpreadsheetAppBar extends React.Component {
                             className={SpreadsheetAppBar.classes.menuButton}
                             color="inherit"
                             aria-label="menu"
-                            onClick={this.menuClickListener}>
+                            href={this.state.settingsLink}>
                     <MenuIcon/>
                 </IconButton>
                 {this.props.children}
@@ -46,5 +74,5 @@ export default class SpreadsheetAppBar extends React.Component {
 }
 
 SpreadsheetAppBar.propTypes = {
-    menuClickListener: PropTypes.func.isRequired, // this is fired when the menu (settings/tools) icon is selected
+    history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1536
- Settings icon (left of spreadsheet name) replace menu listener with history hash push