### PR TITLE
Column & Row range context menu links fix

### DIFF
--- a/cypress/integration/Column.spec.js
+++ b/cypress/integration/Column.spec.js
@@ -2,6 +2,7 @@
 
 import SpreadsheetCellReference from "../../src/spreadsheet/reference/SpreadsheetCellReference.js";
 import SpreadsheetColumnReference from "../../src/spreadsheet/reference/SpreadsheetColumnReference.js";
+import SpreadsheetSelection from "../../src/spreadsheet/reference/SpreadsheetSelection.js";
 import SpreadsheetTesting from "./SpreadsheetTesting.js";
 
 const A1 = SpreadsheetCellReference.parse("A1");
@@ -324,10 +325,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("include.text", "Insert 2 before");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -344,10 +345,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("include.text", "Insert 1 before");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -365,10 +366,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("include.text", "Insert 1 after");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -387,10 +388,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("include.text", "Insert 2 after");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -414,10 +415,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("include.text", "Insert 2 before");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -443,10 +444,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("include.text", "Insert 1 before");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -473,10 +474,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("include.text", "Insert 1 after");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -504,10 +505,10 @@ describe(
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("include.text", "Insert 2 after");
 
-            testing.getById(SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -519,6 +520,31 @@ describe(
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("E3", "Moved");
             testing.cellFormattedTextCheck(C3, "");
+        });
+
+        it("Column range context menu links", () => {
+            testing.hashAppend("/column/B:C");
+
+            testing.contextMenu(C.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/B:C\/insert-after\/1/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/B:C\/insert-after\/2/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/B:C\/insert-before\/1/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/B:C\/insert-before\/2/);
         });
     }
 );

--- a/cypress/integration/Row.spec.js
+++ b/cypress/integration/Row.spec.js
@@ -2,6 +2,7 @@
 
 import SpreadsheetCellReference from "../../src/spreadsheet/reference/SpreadsheetCellReference.js";
 import SpreadsheetRowReference from "../../src/spreadsheet/reference/SpreadsheetRowReference.js";
+import SpreadsheetSelection from "../../src/spreadsheet/reference/SpreadsheetSelection.js";
 import SpreadsheetTesting from "./SpreadsheetTesting.js";
 
 const A1 = SpreadsheetCellReference.parse("A1");
@@ -24,7 +25,7 @@ describe("Row",
 
             testing.spreadsheetEmptyReady();
         });
-
+        
         // row click.................................................................................................
 
         it("Row click should have focus and be selected", () => {
@@ -307,10 +308,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("include.text", "Insert 2 before");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -327,10 +328,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("include.text", "Insert 1 before");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -348,10 +349,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("include.text", "Insert 1 after");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -370,10 +371,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("include.text", "Insert 2 after");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -397,10 +398,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("include.text", "Insert 2 before");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -426,10 +427,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("include.text", "Insert 1 before");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -456,10 +457,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("include.text", "Insert 1 after");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -487,10 +488,10 @@ describe("Row",
 
             testing.viewportContextMenu()
                 .should("be.visible")
-                .find("#" + SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_ID)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("include.text", "Insert 2 after");
 
-            testing.getById(SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_ID)
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .click();
 
             testing.viewportContextMenu()
@@ -502,6 +503,31 @@ describe("Row",
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("C5", "Moved");
             testing.cellFormattedTextCheck(C3, "");
+        });
+
+        it("Row range context menu links", () => {
+            testing.hashAppend("/row/2:3");
+
+            testing.contextMenu(ROW_2.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/2:3\/insert-after\/1/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/2:3\/insert-after\/2/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/2:3\/insert-before\/1/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/2:3\/insert-before\/2/);
         });
     }
 );

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -680,17 +680,31 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
 
         let contextMenuState = {};
 
-        const selection = this.findEventTargetSelection(e.target);
-        if(selection){
+        const clickedSelection = this.findEventTargetSelection(e.target);
+        if(clickedSelection){
             const history = this.props.history;
+            const historyHashTokens = history.tokens();
+            const historyHashTokenSelection = historyHashTokens[SpreadsheetHistoryHashTokens.SELECTION];
+
+            const selection = historyHashTokenSelection && historyHashTokenSelection.viewportContextMenuClick(clickedSelection) ?
+                historyHashTokenSelection :
+                clickedSelection;
+
+            console.log("@@historyHashTokenSelection: " + historyHashTokenSelection +
+                " viewportContextMenuClick: " + clickedSelection +  " -> " +
+                (historyHashTokenSelection && historyHashTokenSelection.viewportContextMenuClick(clickedSelection)) +
+            " selection: " + selection + " items -> " +  selection.viewportContextMenuItems(
+                    SpreadsheetHistoryHash.spreadsheetIdAndName(historyHashTokens),
+                    history
+                ));
 
             contextMenuState = {
                 anchorPosition: {
                     left: e.clientX - 2,
                     top: e.clientY - 4,
                 },
-                menuItems: selection.buildContextMenuItems(
-                    SpreadsheetHistoryHash.spreadsheetIdAndName(history.tokens()),
+                menuItems: selection.viewportContextMenuItems(
+                    SpreadsheetHistoryHash.spreadsheetIdAndName(historyHashTokens),
                     history
                 ),
             }

--- a/src/spreadsheet/reference/SpreadsheetCellRange.js
+++ b/src/spreadsheet/reference/SpreadsheetCellRange.js
@@ -116,11 +116,18 @@ export default class SpreadsheetCellRange extends SpreadsheetExpressionReference
 
     // context menu events..............................................................................................
 
-    buildContextMenuItems(historyTokens) {
+    viewportContextMenuItems(historyTokens) {
         // nop
     }
 
     // viewport.........................................................................................................
+
+    /**
+     * Only returns true if the given clicked is a cell and within this range.
+     */
+    viewportContextMenuClick(clicked) {
+        return clicked instanceof SpreadsheetCellReference && this.testCell(clicked);
+    }
 
     viewportEnter(giveFormulaFocus) {
         // nop TODO later perhaps popup menu

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -246,7 +246,7 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
 
     // context menu events..............................................................................................
 
-    buildContextMenuItems(historyTokens){
+    viewportContextMenuItems(historyTokens){
         return [
             <MenuItem key="click"
                       onClick={() => alert(this.toString())}
@@ -255,6 +255,13 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
     }
 
     // viewport.........................................................................................................
+
+    /**
+     * Only returns true if the given clicked is a cell and m
+     */
+    viewportContextMenuClick(clicked) {
+        return this.equals(clicked);
+    }
 
     viewportEnter(giveFormulaFocus) {
         giveFormulaFocus();

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
@@ -1,14 +1,8 @@
 import Preconditions from "../../Preconditions.js";
 import React from "react";
-import SpreadsheetColumnOrRowInsertAfterHistoryHashToken
-    from "../history/SpreadsheetColumnOrRowInsertAfterHistoryHashToken.js";
-import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
-    from "../history/SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js";
 import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
-import SpreadsheetHistoryHashTokens from "../history/SpreadsheetHistoryHashTokens.js";
 import SpreadsheetReferenceKind from "./SpreadsheetReferenceKind";
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
-import SystemObject from "../../SystemObject.js";
 import TableCell from "@mui/material/TableCell";
 
 
@@ -132,91 +126,15 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
 
     // context menu events..............................................................................................
 
-    // delete
-    // insert 1 before
-    // insert 2 before
-    // insert 1 after
-    // insert 2 after
-    buildContextMenuItems(historyTokens, history) {
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = this;
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = null;
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ANCHOR] = null;
-
-        const menuItems = [];
-
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertBeforeHistoryHashToken(2);
-
-        menuItems.push(
-            history.menuItem(
-                this.viewportInsertBefore2Text(),
-                this.viewportInsertBefore2Id(),
-                historyTokens
-            )
-        );
-
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertBeforeHistoryHashToken(1);
-
-        menuItems.push(
-            history.menuItem(
-                this.viewportInsertBefore1Text(),
-                this.viewportInsertBefore1Id(),
-                historyTokens
-            )
-        );
-
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertAfterHistoryHashToken(1);
-
-        menuItems.push(
-            history.menuItem(
-                this.viewportInsertAfter1Text(),
-                this.viewportInsertAfter1Id(),
-                historyTokens
-            )
-        );
-
-        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertAfterHistoryHashToken(2);
-
-        menuItems.push(
-            history.menuItem(
-                this.viewportInsertAfter2Text(),
-                this.viewportInsertAfter2Id(),
-                historyTokens
-            )
-        );
-
-        return menuItems;
+    viewportContextMenuItems(historyTokens, history) {
+        return this.viewportContextMenuItemsColumnOrRow(historyTokens, history);
     }
 
-    viewportInsertAfter1Id() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertAfter1Text() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertAfter2Id() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertAfter2Text() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertBefore1Id() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertBefore1Text() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertBefore2Id() {
-        SystemObject.throwUnsupportedOperation();
-    }
-
-    viewportInsertBefore2Text() {
-        SystemObject.throwUnsupportedOperation();
+    /**
+     * Only returns true if the given clicked is equal to this column or row
+     */
+    viewportContextMenuClick(clicked) {
+        return this.equals(clicked);
     }
 
     viewportEnter(giveFormulaFocus) {

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReferenceRange.js
@@ -37,6 +37,10 @@ export default class SpreadsheetColumnOrRowReferenceRange extends SpreadsheetSel
 
     // viewport.........................................................................................................
 
+    viewportContextMenuItems(historyTokens, history) {
+        return this.viewportContextMenuItemsColumnOrRow(historyTokens, history);
+    }
+
     viewportEnter(giveFormulaFocus) {
         // ENTER currently is a NOP but will change to perhaps popup a menu
     }

--- a/src/spreadsheet/reference/SpreadsheetColumnReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReference.js
@@ -78,42 +78,27 @@ export default class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRe
 
     // context menu events..............................................................................................
 
-    viewportInsertAfter1Id() {
-        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_ID;
-    }
+    static VIEWPORT_INSERT_AFTER_1_TEXT = "Insert 1 after";
+    static VIEWPORT_INSERT_AFTER_2_TEXT = "Insert 2 after";
+
+    static VIEWPORT_INSERT_BEFORE_1_TEXT = "Insert 1 before";
+    static VIEWPORT_INSERT_BEFORE_2_TEXT = "Insert 2 before";
 
     viewportInsertAfter1Text() {
-        return "Insert 1 after";
-    }
-
-    viewportInsertAfter2Id() {
-        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_ID;
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_TEXT;
     }
 
     viewportInsertAfter2Text() {
-        return "Insert 2 after";
-    }
-
-    viewportInsertBefore1Id() {
-        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_ID;
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_TEXT;
     }
 
     viewportInsertBefore1Text() {
-        return "Insert 1 before";
-    }
-
-    viewportInsertBefore2Id() {
-        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_ID;
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_TEXT;
     }
 
     viewportInsertBefore2Text() {
-        return "Insert 2 before";
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_TEXT;
     }
-
-    static VIEWPORT_INSERT_BEFORE_2_ID = "viewport-column-insert-before-2";
-    static VIEWPORT_INSERT_BEFORE_1_ID = "viewport-column-insert-before-1";
-    static VIEWPORT_INSERT_AFTER_1_ID = "viewport-column-insert-after-1";
-    static VIEWPORT_INSERT_AFTER_2_ID = "viewport-column-insert-after-2";
 
     viewportId() {
         return "viewport-column-" + this.toString().toUpperCase();

--- a/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
@@ -75,12 +75,6 @@ export default class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOr
         return false;
     }
 
-    // context menu events..............................................................................................
-
-    buildContextMenuItems(historyTokens){
-        // nop
-    }
-
     toLoadCellsQueryStringParameterSelectionType() {
         return "column-range";
     }
@@ -128,6 +122,29 @@ export default class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOr
     }
 
     // viewport.........................................................................................................
+
+    /**
+     * Only returns true if the given clicked is a column within this range.
+     */
+    viewportContextMenuClick(clicked) {
+        return clicked instanceof SpreadsheetColumnReference && this.testColumn(clicked);
+    }
+
+    viewportInsertAfter1Text() {
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_1_TEXT;
+    }
+
+    viewportInsertAfter2Text() {
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_AFTER_2_TEXT;
+    }
+
+    viewportInsertBefore1Text() {
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_1_TEXT;
+    }
+
+    viewportInsertBefore2Text() {
+        return SpreadsheetColumnReference.VIEWPORT_INSERT_BEFORE_2_TEXT;
+    }
 
     viewportFocus(labelToReference, anchor) {
         let focus;

--- a/src/spreadsheet/reference/SpreadsheetRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReference.js
@@ -85,42 +85,33 @@ export default class SpreadsheetRowReference extends SpreadsheetColumnOrRowRefer
         return "row";
     }
 
-    viewportInsertAfter1Id() {
-        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_ID;
-    }
+    static VIEWPORT_INSERT_AFTER_1_TEXT = "Insert 1 after";
+    static VIEWPORT_INSERT_AFTER_2_TEXT = "Insert 2 after";
+
+    static VIEWPORT_INSERT_BEFORE_1_TEXT = "Insert 1 before";
+    static VIEWPORT_INSERT_BEFORE_2_TEXT = "Insert 2 before";
+
+    static VIEWPORT_INSERT_AFTER_1_ID = "viewport-row-insert-after-1";
+    static VIEWPORT_INSERT_AFTER_2_ID = "viewport-row-insert-after-2";
+
+    static VIEWPORT_INSERT_BEFORE_1_ID = "viewport-row-insert-before-1";
+    static VIEWPORT_INSERT_BEFORE_2_ID = "viewport-row-insert-before-2";
 
     viewportInsertAfter1Text() {
-        return "Insert 1 after";
-    }
-
-    viewportInsertAfter2Id() {
-        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_ID;
+        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_TEXT;
     }
 
     viewportInsertAfter2Text() {
-        return "Insert 2 after";
-    }
-
-    viewportInsertBefore1Id() {
-        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_ID;
+        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_TEXT;
     }
 
     viewportInsertBefore1Text() {
-        return "Insert 1 before";
-    }
-
-    viewportInsertBefore2Id() {
-        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_ID;
+        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_TEXT;
     }
 
     viewportInsertBefore2Text() {
-        return "Insert 2 before";
+        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_TEXT;
     }
-    
-    static VIEWPORT_INSERT_BEFORE_2_ID = "viewport-row-insert-before-2";
-    static VIEWPORT_INSERT_BEFORE_1_ID = "viewport-row-insert-before-1";
-    static VIEWPORT_INSERT_AFTER_1_ID = "viewport-row-insert-after-1";
-    static VIEWPORT_INSERT_AFTER_2_ID = "viewport-row-insert-after-2";
 
     viewportId() {
         return "viewport-row-" + this.toString().toUpperCase();

--- a/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
@@ -75,12 +75,6 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
             this.end().compareTo(rowReference) >= 0;
     }
 
-    // context menu events..............................................................................................
-
-    buildContextMenuItems(historyTokens) {
-        // nop
-    }
-
     toLoadCellsQueryStringParameterSelectionType() {
         return "row-range";
     }
@@ -129,6 +123,29 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
 
     // viewport.........................................................................................................
 
+    /**
+     * Only returns true if the given clicked is a row within this range.
+     */
+    viewportContextMenuClick(clicked) {
+        return clicked instanceof SpreadsheetRowReference && this.testRow(clicked);
+    }
+
+    viewportInsertAfter1Text() {
+        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_1_TEXT;
+    }
+
+    viewportInsertAfter2Text() {
+        return SpreadsheetRowReference.VIEWPORT_INSERT_AFTER_2_TEXT;
+    }
+
+    viewportInsertBefore1Text() {
+        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_1_TEXT;
+    }
+
+    viewportInsertBefore2Text() {
+        return SpreadsheetRowReference.VIEWPORT_INSERT_BEFORE_2_TEXT;
+    }
+    
     viewportFocus(labelToReference, anchor) {
         let focus;
 

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -1,6 +1,11 @@
 import CharSequences from "../../CharSequences.js";
 import Character from "../../Character.js";
 import Keys from "../../Keys.js";
+import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
+    from "../history/SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js";
+import SpreadsheetColumnOrRowInsertAfterHistoryHashToken
+    from "../history/SpreadsheetColumnOrRowInsertAfterHistoryHashToken.js";
+import SpreadsheetHistoryHashTokens from "../history/SpreadsheetHistoryHashTokens.js";
 import SpreadsheetViewportSelection from "./SpreadsheetViewportSelection.js";
 import SystemObject from "../../SystemObject.js";
 
@@ -77,16 +82,6 @@ export default class SpreadsheetSelection extends SystemObject {
         SystemObject.throwUnsupportedOperation();
     }
 
-    // context menu events..............................................................................................
-
-    /**
-     * This method is called whenever the element for this selection is clicked, providing an opportunity to
-     * build the context menu items that will be displayed ready for clicking.
-     */
-    buildContextMenuItems(historyTokens){
-        SystemObject.throwUnsupportedOperation();
-    }
-
     // key events.......................................................................................................
 
     /**
@@ -138,6 +133,79 @@ export default class SpreadsheetSelection extends SystemObject {
         }
     }
 
+    viewportContextMenuClick(clicked) {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    /**
+     * This method is called whenever the element for this selection is clicked, providing an opportunity to
+     * build the context menu items that will be displayed ready for clicking.
+     */
+    viewportContextMenuItems(historyTokens){
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    static VIEWPORT_CONTEXT_MENU_ID = "viewport-context-menu";
+    static VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-after-2";
+    static VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-after-1"
+    static VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-before-2";
+    static VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-before-1";
+
+    // delete
+    // insert 1 before
+    // insert 2 before
+    // insert 1 after
+    // insert 2 after
+    viewportContextMenuItemsColumnOrRow(historyTokens, history) {
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = this;
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = null;
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ANCHOR] = null;
+
+        const menuItems = [];
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertBeforeHistoryHashToken(2);
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportInsertBefore2Text(),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID,
+                historyTokens
+            )
+        );
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertBeforeHistoryHashToken(1);
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportInsertBefore1Text(),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID,
+                historyTokens
+            )
+        );
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertAfterHistoryHashToken(1);
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportInsertAfter1Text(),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID,
+                historyTokens
+            )
+        );
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowInsertAfterHistoryHashToken(2);
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportInsertAfter2Text(),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID,
+                historyTokens
+            )
+        );
+
+        return menuItems;
+    }
+
     viewportEnter(giveFormulaFocus) {
         SystemObject.throwUnsupportedOperation();
     }
@@ -176,6 +244,38 @@ export default class SpreadsheetSelection extends SystemObject {
 
     viewportDownExtend(start) {
         SystemObject.throwUnsupportedOperation()
+    }
+
+    viewportInsertAfter1Id() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertAfter1Text() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertAfter2Id() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertAfter2Text() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertBefore1Id() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertBefore1Text() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertBefore2Id() {
+        SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportInsertBefore2Text() {
+        SystemObject.throwUnsupportedOperation();
     }
 
     static reportInvalidAnchor(anchor) {


### PR DESCRIPTION
- Links now correctly built with range selection and not the clicked target if clicked is within range.
- Simplified context menu link item ids.

- https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1581
- Context menu for column range, menu urls are incorrect (show single column/row) not range.