### PR TITLE
SpreadsheetSettings save fix

### DIFF
--- a/src/spreadsheet/history/SpreadsheetSettingsSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetSettingsSaveHistoryHashToken.js
@@ -26,7 +26,7 @@ export default class SpreadsheetSettingsSaveHistoryHashToken extends Spreadsheet
     }
 
     onSettingsAction(settingsWidget) {
-        settingsWidget.patchMetadataWithName(this.value());
+        settingsWidget.patchSpreadsheetMetadata(this.value());
     }
 
 


### PR DESCRIPTION
- previous refactor probably during last SpreadsheetNameWidget cause breakage.