### PR TITLE
insertAfterSelection & insertBeforeSelection missing window fix

### DIFF
--- a/src/spreadsheet/SpreadsheetApp.js
+++ b/src/spreadsheet/SpreadsheetApp.js
@@ -397,7 +397,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
      * Does a POST to a url which will insert after the requested count columns or rows.
      */
     insertAfterSelection(selection, count, window) {
-        const query = window ? "?window=" + window : "";
+        const query = window ? "&window=" + window : "";
 
         this.performSpreadsheetDelta(
             HttpMethod.POST,
@@ -410,7 +410,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
      * Does a POST to a url which will insert before the requested count columns or rows.
      */
     insertBeforeSelection(selection, count, window) {
-        const query = window ? "?window=" + window : "";
+        const query = window ? "&window=" + window : "";
 
         this.performSpreadsheetDelta(
             HttpMethod.POST,

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -573,14 +573,22 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
      * Performs the insertAfter operation, leaving the selection unchanged.
      */
     insertAfterSelection(selection, count) {
-        this.props.insertAfterSelection(selection, count);
+        this.props.insertAfterSelection(
+            selection,
+            count,
+            this.state.viewportRange
+        );
     }
 
     /**
      * Performs the insert-before operation, leaving the selection unchanged.
      */
     insertBeforeSelection(selection, count) {
-        this.props.insertBeforeSelection(selection, count);
+        this.props.insertBeforeSelection(
+            selection,
+            count,
+            this.state.viewportRange
+        );
     }
 
     /**


### PR DESCRIPTION
- SpreadsheetViewportWidget was failing to add current viewport window parameter.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1737
- insertAfter & insertBefore REST end point urls are missing window query parameter.