### PR TITLE
History hash hidden selection cleared

### DIFF
--- a/cypress/integration/Column.spec.js
+++ b/cypress/integration/Column.spec.js
@@ -774,6 +774,60 @@ describe(
             testing.cellFormattedTextCheck("D4", "After");
         });
 
+        it("Attempt to history hash select hidden column cleared", () => {
+            testing.contextMenu(B.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible")
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .should("include.text", "Hide");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .click();
+
+            testing.viewportContextMenu()
+                .should("not.be.visible");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+
+            testing.hashAppend("/column/B");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+        });
+
+        it("Attempt to history hash select cell in hidden column cleared", () => {
+            testing.contextMenu(B.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible")
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .should("include.text", "Hide");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .click();
+
+            testing.viewportContextMenu()
+                .should("not.be.visible");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+
+            testing.hashAppend("/cell/B2");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+        });
+
         // unhide ......................................................................................................
 
         it("Column context menu click unhide column after", () => {

--- a/cypress/integration/Row.spec.js
+++ b/cypress/integration/Row.spec.js
@@ -757,6 +757,60 @@ describe("Row",
             testing.cellFormattedTextCheck("D4", "After");
         });
 
+        it("Attempt to history hash select hidden row cleared", () => {
+            testing.contextMenu(ROW_2.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible")
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .should("include.text", "Hide");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .click();
+
+            testing.viewportContextMenu()
+                .should("not.be.visible");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+
+            testing.hashAppend("/row/2");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+        });
+
+        it("Attempt to history hash select cell in hidden row cleared", () => {
+            testing.contextMenu(ROW_2.viewportId());
+
+            testing.viewportContextMenu()
+                .should("be.visible")
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .should("include.text", "Hide");
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
+                .click();
+
+            testing.viewportContextMenu()
+                .should("not.be.visible");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+
+            testing.hashAppend("/cell/B2");
+
+            testing.columnWait();
+
+            testing.hash()
+                .should('match', /.*\/.*/);
+        });
+
         // unhide ......................................................................................................
 
         it("Row context menu click unhide row after", () => {

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -231,18 +231,17 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                     );
                 }
 
-                if(queryParameterSelection || requestDelta && requestDelta.selection()) {
+                // if the request SpreadsheetDelta#viewportSelection was present then update the state with the response SpreadsheetDelta#viewportSelection
+                if(queryParameterSelection || requestDelta && requestDelta.selection()){
                     const viewportSelection = responseDelta.selection();
-                    if(viewportSelection){
-                        Object.assign(
-                            newState,
-                            {
-                                selection: viewportSelection ? viewportSelection.selection() : null,
-                                selectionAnchor: viewportSelection ? viewportSelection.anchor() : null,
-                                selectionNavigation: viewportSelection ? viewportSelection.navigation() : null,
-                            }
-                        );
-                    }
+                    Object.assign(
+                        newState,
+                        {
+                            selection: viewportSelection ? viewportSelection.selection() : null,
+                            selectionAnchor: viewportSelection ? viewportSelection.anchor() : null,
+                            selectionNavigation: viewportSelection ? viewportSelection.navigation() : null,
+                        }
+                    );
                 }
             }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1728
- History hash shouldnt allow selection of hidden columns/row