### PR TITLE
formula save includes window

### DIFF
--- a/src/spreadsheet/SpreadsheetApp.js
+++ b/src/spreadsheet/SpreadsheetApp.js
@@ -338,6 +338,7 @@ class SpreadsheetApp extends SpreadsheetHistoryAwareStateWidget {
                     <SpreadsheetFormulaWidget ref={this.formula}
                                               key={"spreadsheetFormula"}
                                               history={history}
+                                              spreadsheetViewportWidget={this.viewport}
                                               spreadsheetDeltaCellCrud={spreadsheetDeltaCellCrud}
                                               showError={showError}
                     />

--- a/src/spreadsheet/SpreadsheetFormulaWidget.js
+++ b/src/spreadsheet/SpreadsheetFormulaWidget.js
@@ -1,13 +1,9 @@
 import CharSequences from "../CharSequences.js";
 import Equality from "../Equality.js";
-import ImmutableMap from "../util/ImmutableMap.js";
 import Keys from "../Keys.js";
 import PropTypes from "prop-types";
 import React from 'react';
-import SpreadsheetCell from "./SpreadsheetCell.js";
 import SpreadsheetCellReferenceOrLabelName from "./reference/SpreadsheetCellReferenceOrLabelName.js";
-import SpreadsheetDelta from "./engine/SpreadsheetDelta.js";
-import SpreadsheetFormula from "./SpreadsheetFormula.js";
 import SpreadsheetFormulaLoadAndEditHistoryHashToken from "./history/SpreadsheetFormulaLoadAndEditHistoryHashToken.js";
 import SpreadsheetFormulaSaveHistoryHashToken from "./history/SpreadsheetFormulaSaveHistoryHashToken.js";
 import SpreadsheetHistoryHash from "./history/SpreadsheetHistoryHash.js";
@@ -17,7 +13,6 @@ import SpreadsheetLabelName from "./reference/SpreadsheetLabelName.js";
 import SpreadsheetMessengerCrud from "./message/SpreadsheetMessengerCrud.js";
 import SpreadsheetViewportWidget from "./SpreadsheetViewportWidget.js";
 import TextField from '@mui/material/TextField';
-import TextStyle from "../text/TextStyle.js";
 
 /**
  * A widget that supports editing formula text.
@@ -134,40 +129,11 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
         );
     }
 
-    /**
-     * Saves the given formula text to the given cell, including the creation of new cells that were previously empty.
-     * This assumes that the cell being saved has been loaded.
-     */
     saveFormulaText(cellReference, selection, formulaText) {
-        console.log("saving formula for " + selection + " with " + CharSequences.quoteAndEscape(formulaText));
-
-        var cell = new SpreadsheetCell(
+        this.props.spreadsheetViewportWidget.current.saveFormulaText(
             cellReference,
-            new SpreadsheetFormula(formulaText),
-            TextStyle.EMPTY
-        );
-
-        const tokens = SpreadsheetHistoryHashTokens.emptyTokens();
-        tokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetFormulaLoadAndEditHistoryHashToken();
-        this.historyParseMergeAndPush(tokens);
-
-        const props = this.props;
-        props.spreadsheetDeltaCellCrud.patch(
-            cellReference,
-            new SpreadsheetDelta(
-                null,
-                [cell],
-                [],
-                [],
-                [],
-                [],
-                [],
-                [],
-                ImmutableMap.EMPTY,
-                ImmutableMap.EMPTY,
-                []
-            ),
-            props.showError,
+            selection,
+            formulaText
         );
     }
 
@@ -307,5 +273,6 @@ export default class SpreadsheetFormulaWidget extends SpreadsheetHistoryAwareSta
 SpreadsheetFormulaWidget.propTypes = {
     history: PropTypes.instanceOf(SpreadsheetHistoryHash).isRequired,
     spreadsheetDeltaCellCrud: PropTypes.instanceOf(SpreadsheetMessengerCrud),
+    spreadsheetViewportWidget: PropTypes.instanceOf(SpreadsheetViewportWidget),
     showError: PropTypes.func.isRequired,
 }

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import CharSequences from "../CharSequences.js";
 import Equality from "../Equality.js";
 import HttpMethod from "../net/HttpMethod.js";
 import ImmutableMap from "../util/ImmutableMap.js";
@@ -9,6 +10,7 @@ import Preconditions from "../Preconditions.js";
 import PropTypes from "prop-types";
 import React from 'react';
 import Slider from "@mui/material/Slider";
+import SpreadsheetCell from "./SpreadsheetCell.js";
 import SpreadsheetCellColumnOrRowParse from "./reference/SpreadsheetCellColumnOrRowParse.js";
 import SpreadsheetCellMenuHistoryHashToken from "./history/SpreadsheetCellMenuHistoryHashToken.js";
 import SpreadsheetCellRange from "./reference/SpreadsheetCellRange.js";
@@ -21,6 +23,7 @@ import SpreadsheetColumnOrRowMenuHistoryHashToken from "./history/SpreadsheetCol
 import SpreadsheetColumnReference from "./reference/SpreadsheetColumnReference.js";
 import SpreadsheetColumnReferenceRange from "./reference/SpreadsheetColumnReferenceRange.js";
 import SpreadsheetDelta from "./engine/SpreadsheetDelta.js";
+import SpreadsheetFormula from "./SpreadsheetFormula.js";
 import SpreadsheetFormulaHistoryHashToken from "./history/SpreadsheetFormulaHistoryHashToken.js";
 import SpreadsheetFormulaLoadAndEditHistoryHashToken from "./history/SpreadsheetFormulaLoadAndEditHistoryHashToken.js";
 import SpreadsheetHistoryAwareStateWidget from "./history/SpreadsheetHistoryAwareStateWidget.js";
@@ -46,6 +49,7 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TextStyle from "../text/TextStyle.js";
 
 // default header cell styles
 
@@ -676,6 +680,43 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                 props.showError,
             );
         }
+    }
+
+    /**
+     * Saves the given formula text to the given cell, including the creation of new cells that were previously empty.
+     * This assumes that the cell being saved has been loaded.
+     */
+    saveFormulaText(cellReference, selection, formulaText) {
+        console.log("saving formula for " + selection + " with " + CharSequences.quoteAndEscape(formulaText));
+
+        var cell = new SpreadsheetCell(
+            cellReference,
+            new SpreadsheetFormula(formulaText),
+            TextStyle.EMPTY
+        );
+
+        const tokens = SpreadsheetHistoryHashTokens.emptyTokens();
+        tokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetFormulaLoadAndEditHistoryHashToken();
+        this.historyParseMergeAndPush(tokens);
+
+        const props = this.props;
+        props.spreadsheetDeltaCellCrud.patch(
+            cellReference,
+            new SpreadsheetDelta(
+                null,
+                [cell],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                ImmutableMap.EMPTY,
+                ImmutableMap.EMPTY,
+                this.state.window,
+            ),
+            props.showError,
+        );
     }
 
     /**


### PR DESCRIPTION
- move saveFormulaText to SpreadsheetViewportWidget, which tracks the current window.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1599
- save formula not including window = viewport parameter, currently window is absent