### PR TITLE
ContextMenu freeze columns/rows menu items

### DIFF
--- a/cypress/integration/Column.spec.js
+++ b/cypress/integration/Column.spec.js
@@ -307,7 +307,7 @@ describe(
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 7);
+                .should("have.length", 10);
         });
 
         it("Column context menu", () => {
@@ -319,7 +319,7 @@ describe(
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 7);
+                .should("have.length", 10);
         });
 
         it("Column context menu links", () => {
@@ -353,6 +353,18 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/column\/B\/insert-before\/2/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A:B\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A:C\/freeze/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
@@ -390,6 +402,18 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/column\/B:C\/insert-before\/2/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A:B\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/column\/A:C\/freeze/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")

--- a/cypress/integration/Row.spec.js
+++ b/cypress/integration/Row.spec.js
@@ -294,7 +294,7 @@ describe("Row",
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 7);
+                .should("have.length", 10);
         });
 
         it("Row context menu", () => {
@@ -306,7 +306,7 @@ describe("Row",
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 7);
+                .should("have.length", 10);
         });
 
         it("Row context menu links", () => {
@@ -341,6 +341,18 @@ describe("Row",
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/row\/2\/insert-before\/2/);
 
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1:2\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1:3\/freeze/);
+            
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/row\/2\/hidden\/true/);
@@ -377,6 +389,18 @@ describe("Row",
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/row\/2:3\/insert-before\/2/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1:2\/freeze/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
+                .should("have.attr", "href")
+                .and('match', /#*\/*\/row\/1:3\/freeze/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -760,6 +760,14 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                     SpreadsheetHistoryHash.spreadsheetIdAndName(history.tokens()),
                     (c) => this.isColumnHidden(c),
                     (r) => this.isRowHidden(r),
+                    (c) => new SpreadsheetColumnReferenceRange(
+                        new SpreadsheetColumnReference(0, SpreadsheetReferenceKind.RELATIVE),
+                        new SpreadsheetColumnReference(c, SpreadsheetReferenceKind.RELATIVE)
+                    ),
+                    (r) => new SpreadsheetRowReferenceRange(
+                        new SpreadsheetRowReference(0, SpreadsheetReferenceKind.RELATIVE),
+                        new SpreadsheetRowReference(r, SpreadsheetReferenceKind.RELATIVE)
+                    ),
                     history
                 ),
             };

--- a/src/spreadsheet/reference/SpreadsheetColumnReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReference.js
@@ -87,12 +87,13 @@ export default class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRe
 
     // context menu events..............................................................................................
 
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history) {
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history) {
         return this.viewportContextMenuItemsColumnOrRow(
             historyTokens,
             this.addSaturated(-1),
             this.addSaturated(+1),
             isColumnHidden,
+            columnRange,
             history
         );
     }

--- a/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
@@ -147,12 +147,13 @@ export default class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOr
 
     // viewport.........................................................................................................
 
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history) {
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history) {
         return this.viewportContextMenuItemsColumnOrRow(
             historyTokens,
             this.begin().addSaturated(-1),
             this.end().addSaturated(+1),
             isColumnHidden,
+            columnRange,
             history
         );
     }

--- a/src/spreadsheet/reference/SpreadsheetExpressionReference.js
+++ b/src/spreadsheet/reference/SpreadsheetExpressionReference.js
@@ -19,7 +19,7 @@ export default class SpreadsheetExpressionReference extends SpreadsheetSelection
         return /*SpreadsheetHistoryHash.CELL*/ "cell/" + this;
     }
 
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history) {
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history) {
         return this.viewportContextMenuItemsCell(historyTokens, history);
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReference.js
@@ -90,12 +90,13 @@ export default class SpreadsheetRowReference extends SpreadsheetColumnOrRowRefer
 
     // context menu events..............................................................................................
 
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history) {
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history) {
         return this.viewportContextMenuItemsColumnOrRow(
             historyTokens,
             this.addSaturated(-1),
             this.addSaturated(+1),
             isRowHidden,
+            rowRange,
             history
         );
     }

--- a/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
@@ -148,12 +148,13 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
 
     // viewport.........................................................................................................
 
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history) {
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history) {
         return this.viewportContextMenuItemsColumnOrRow(
             historyTokens,
             this.begin().addSaturated(-1),
             this.end().addSaturated(+1),
             isRowHidden,
+            rowRange,
             history
         );
     }

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -3,6 +3,7 @@ import Character from "../../Character.js";
 import SpreadsheetCellDeleteHistoryHashToken from "../history/SpreadsheetCellDeleteHistoryHashToken.js";
 import SpreadsheetColumnOrRowClearHistoryHashToken from "../history/SpreadsheetColumnOrRowClearHistoryHashToken.js";
 import SpreadsheetColumnOrRowDeleteHistoryHashToken from "../history/SpreadsheetColumnOrRowDeleteHistoryHashToken.js";
+import SpreadsheetColumnOrRowFreezeHistoryHashToken from "../history/SpreadsheetColumnOrRowFreezeHistoryHashToken.js";
 import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
     from "../history/SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js";
 import SpreadsheetColumnOrRowInsertAfterHistoryHashToken
@@ -117,7 +118,7 @@ export default class SpreadsheetSelection extends SystemObject {
      * This method is called whenever the element for this selection is clicked, providing an opportunity to
      * build the context menu items that will be displayed ready for clicking.
      */
-    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, history){
+    viewportContextMenuItems(historyTokens, isColumnHidden, isRowHidden, columnRange, rowRange, history){
         SystemObject.throwUnsupportedOperation();
     }
 
@@ -132,6 +133,12 @@ export default class SpreadsheetSelection extends SystemObject {
 
     // the id for the "delete row" menu item
     static VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-delete-row";
+
+    // the id for the freeze column or row menu item.
+    static VIEWPORT_CONTEXT_MENU_FREEZE_1_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-freeze-1";
+    static VIEWPORT_CONTEXT_MENU_FREEZE_2_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-freeze-2";
+    static VIEWPORT_CONTEXT_MENU_FREEZE_3_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-freeze-3";
+    static VIEWPORT_CONTEXT_MENU_FREEZE_RANGE_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-freeze-range";
 
     // the id for the hide column or row menu item.
     static VIEWPORT_CONTEXT_MENU_HIDE_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-hide";
@@ -199,7 +206,7 @@ export default class SpreadsheetSelection extends SystemObject {
     // insert 2 before
     // insert 1 after
     // insert 2 after
-    viewportContextMenuItemsColumnOrRow(historyTokens, before, after, isHidden, history) {
+    viewportContextMenuItemsColumnOrRow(historyTokens, before, after, isHidden, range, history) {
         historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = this;
         historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = null;
         historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ANCHOR] = null;
@@ -274,8 +281,48 @@ export default class SpreadsheetSelection extends SystemObject {
             )
         );
 
+        // freeze.......................................................................................................
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = SpreadsheetColumnOrRowFreezeHistoryHashToken.INSTANCE;
+
+        const range1 = range(0);
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = range1;
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportFreezeColumnsRowsText(range1),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID,
+                historyTokens
+            )
+        );
+
+        // freeze columns A:B / row 1:2
+        const range2 = range(1);
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = range2;
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportFreezeColumnsRowsText(range2),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID,
+                historyTokens
+            )
+        );
+
+        // freeze columns A:C / row 1:3
+        const range3 = range(2);
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = range3;
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportFreezeColumnsRowsText(range3),
+                SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID,
+                historyTokens
+            )
+        );
+
         // hide........................................................................................................
 
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = this;
         historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = new SpreadsheetColumnOrRowSaveHistoryHashToken("hidden", true);
 
         menuItems.push(
@@ -339,6 +386,10 @@ export default class SpreadsheetSelection extends SystemObject {
 
     viewportDeleteRowText() {
         SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportFreezeColumnsRowsText(columns) {
+        return "Freeze " + columns;
     }
 
     viewportHideText() {


### PR DESCRIPTION
- Fixed adds freeze first 1 - 3 columns/rows ignores any selection

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1756
- Column / row context menu freeze [ 1 ... 3 ] for column & cell OR row & cell