### PR TITLE
Unfreeze column/rows context menu item

### DIFF
--- a/cypress/integration/Column.spec.js
+++ b/cypress/integration/Column.spec.js
@@ -307,7 +307,7 @@ describe(
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 10);
+                .should("have.length", 11);
         });
 
         it("Column context menu", () => {
@@ -319,7 +319,7 @@ describe(
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 10);
+                .should("have.length", 11);
         });
 
         it("Column context menu links", () => {
@@ -369,6 +369,8 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/column\/B\/hidden\/true/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
 
         it("Column range context menu links", () => {
@@ -418,6 +420,8 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/column\/B:C\/hidden\/true/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
 
         it("Column context menu click clear", () => {

--- a/cypress/integration/Row.spec.js
+++ b/cypress/integration/Row.spec.js
@@ -294,7 +294,7 @@ describe("Row",
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 10);
+                .should("have.length", 11);
         });
 
         it("Row context menu", () => {
@@ -306,7 +306,7 @@ describe("Row",
             testing.viewportContextMenu()
                 .should("be.visible")
                 .find("LI")
-                .should("have.length", 10);
+                .should("have.length", 11);
         });
 
         it("Row context menu links", () => {
@@ -356,6 +356,8 @@ describe("Row",
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/row\/2\/hidden\/true/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
 
         it("Row range context menu links", () => {
@@ -405,6 +407,8 @@ describe("Row",
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
                 .and('match', /#*\/*\/row\/2:3\/hidden\/true/);
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
 
         it("Row context menu click clear", () => {

--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -739,6 +739,17 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
         );
     }
 
+    unFreezeSelection(viewportSelection) {
+        const selection = viewportSelection.selection();
+
+        this.patchSpreadsheetMetadata(
+            selection.apiFreezeMetadataPropertyName(),
+            null
+        );
+
+        this.removeHistoryHashSelectionAction();
+    }
+
     /**
      * Updates the state so the context menu will be shown.
      */

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js
@@ -1,0 +1,28 @@
+import SpreadsheetColumnOrRowHistoryHashToken from "./SpreadsheetColumnOrRowHistoryHashToken.js";
+import SpreadsheetHistoryHashTokens from "./SpreadsheetHistoryHashTokens.js";
+
+/**
+ * Represents a command to unfreeze a column or row selection.
+ */
+export default class SpreadsheetColumnOrRowUnFreezeHistoryHashToken extends SpreadsheetColumnOrRowHistoryHashToken {
+
+    /**
+     * Singleton instance.
+     */
+    static INSTANCE = new SpreadsheetColumnOrRowUnFreezeHistoryHashToken();
+
+    toHistoryHashToken() {
+        return SpreadsheetHistoryHashTokens.UNFREEZE;
+    }
+
+    /**
+     * Handles history hash token evens such as /column/A/unfreeze or /column/A:C/unfreeze
+     */
+    onViewportSelectionAction(viewportSelection, viewportWidget) {
+        viewportWidget.unFreezeSelection(viewportSelection);
+    }
+
+    equals(other) {
+        return this === other || (other instanceof SpreadsheetColumnOrRowUnFreezeHistoryHashToken);
+    }
+}

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -20,6 +20,7 @@ import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
     from "./SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js";
 import SpreadsheetColumnOrRowMenuHistoryHashToken from "./SpreadsheetColumnOrRowMenuHistoryHashToken.js";
 import SpreadsheetColumnOrRowSaveHistoryHashToken from "./SpreadsheetColumnOrRowSaveHistoryHashToken.js";
+import SpreadsheetColumnOrRowUnFreezeHistoryHashToken from "./SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js";
 import SpreadsheetColumnReferenceRange from "../reference/SpreadsheetColumnReferenceRange.js";
 import SpreadsheetFormulaLoadAndEditHistoryHashToken from "./SpreadsheetFormulaLoadAndEditHistoryHashToken.js";
 import SpreadsheetFormulaSaveHistoryHashToken from "./SpreadsheetFormulaSaveHistoryHashToken.js";
@@ -282,6 +283,15 @@ export default class SpreadsheetHistoryHash extends SpreadsheetHistoryHashTokens
                                                     if(SpreadsheetHistoryHashTokens.MENU === token){
                                                         selectionAction = SpreadsheetColumnOrRowMenuHistoryHashToken.INSTANCE;
                                                         token = tokens.shift();
+                                                    } else {
+                                                        if(SpreadsheetHistoryHashTokens.UNFREEZE === token){
+                                                            if(!selection.canFreeze()){
+                                                                selection = null;
+                                                            }else {
+                                                                selectionAction = SpreadsheetColumnOrRowUnFreezeHistoryHashToken.INSTANCE;
+                                                            }
+                                                            token = tokens.shift();
+                                                        }
                                                     }
                                                 }
                                             }

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -12,6 +12,7 @@ import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
     from "./SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js";
 import SpreadsheetColumnOrRowMenuHistoryHashToken from "./SpreadsheetColumnOrRowMenuHistoryHashToken.js";
 import SpreadsheetColumnOrRowSaveHistoryHashToken from "./SpreadsheetColumnOrRowSaveHistoryHashToken.js";
+import SpreadsheetColumnOrRowUnFreezeHistoryHashToken from "./SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js";
 import SpreadsheetColumnReference from "../reference/SpreadsheetColumnReference.js";
 import SpreadsheetColumnReferenceRange from "../reference/SpreadsheetColumnReferenceRange.js";
 import SpreadsheetFormulaLoadAndEditHistoryHashToken from "./SpreadsheetFormulaLoadAndEditHistoryHashToken.js";
@@ -55,6 +56,7 @@ const NEW_LABEL = SpreadsheetLabelName.parse("Label999");
 const COLUMN_ROW_CLEAR = SpreadsheetColumnOrRowClearHistoryHashToken.INSTANCE;
 const COLUMN_ROW_FREEZE = SpreadsheetColumnOrRowFreezeHistoryHashToken.INSTANCE;
 const COLUMN_ROW_MENU = SpreadsheetColumnOrRowMenuHistoryHashToken.INSTANCE;
+const COLUMN_ROW_UNFREEZE = SpreadsheetColumnOrRowUnFreezeHistoryHashToken.INSTANCE;
 
 const CELL_CLEAR = SpreadsheetCellClearHistoryHashToken.INSTANCE;
 const CELL_DELETE = SpreadsheetCellDeleteHistoryHashToken.INSTANCE;
@@ -1118,6 +1120,34 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/A/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": COLUMN_A,
+        "selection-action": COLUMN_ROW_UNFREEZE,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/A:C/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": COLUMN_RANGE_AC,
+        "selection-action": COLUMN_ROW_UNFREEZE,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/column/B:C/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+    }
+);
+
+testParseAndStringify(
     "/spreadsheet-id-123/spreadsheet-name-456/column/B/formula",
     {
         "spreadsheet-id": "spreadsheet-id-123",
@@ -1497,6 +1527,42 @@ testParseAndStringify(
         "spreadsheet-name": SPREADSHEET_NAME,
         "selection": ROW,
         "selection-action": COLUMN_ROW_MENU,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/1/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": ROW_1,
+        "selection-action": COLUMN_ROW_UNFREEZE,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/1:3/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "selection": ROW_RANGE_1_3,
+        "selection-action": COLUMN_ROW_UNFREEZE,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/row/2:3/unfreeze",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME
     }
 );
 

--- a/src/spreadsheet/history/SpreadsheetHistoryHashTokens.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHashTokens.js
@@ -39,6 +39,7 @@ export default class SpreadsheetHistoryHashTokens {
     static INSERT_AFTER = "insert-after";
     static INSERT_BEFORE = "insert-before";
     static MENU = "menu";
+    static UNFREEZE = "unfreeze";
 
     static SAVE = "save";
 

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -9,6 +9,8 @@ import SpreadsheetColumnOrRowInsertBeforeHistoryHashToken
 import SpreadsheetColumnOrRowInsertAfterHistoryHashToken
     from "../history/SpreadsheetColumnOrRowInsertAfterHistoryHashToken.js";
 import SpreadsheetColumnOrRowSaveHistoryHashToken from "../history/SpreadsheetColumnOrRowSaveHistoryHashToken.js";
+import SpreadsheetColumnOrRowUnFreezeHistoryHashToken
+    from "../history/SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js";
 import SpreadsheetHistoryHashTokens from "../history/SpreadsheetHistoryHashTokens.js";
 import SpreadsheetViewportSelection from "./SpreadsheetViewportSelection.js";
 import SystemObject from "../../SystemObject.js";
@@ -147,6 +149,8 @@ export default class SpreadsheetSelection extends SystemObject {
     static VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-after-1"
     static VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-before-2";
     static VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-insert-before-1";
+
+    static VIEWPORT_CONTEXT_MENU_UNFREEZE_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-unfreeze";
 
     static VIEWPORT_CONTEXT_MENU_UNHIDE_AFTER_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-unhide-after";
     static VIEWPORT_CONTEXT_MENU_UNHIDE_BEFORE_ID = SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_ID + "-unhide-before";
@@ -319,6 +323,14 @@ export default class SpreadsheetSelection extends SystemObject {
             history
         );
 
+        this.viewportContextMenuItemsColumnOrRowUnFreeze(
+            historyTokens,
+            frozenColumnOrRows,
+            menuItems,
+            SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID,
+            history
+        );
+
         // hide........................................................................................................
 
         historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = this;
@@ -365,6 +377,22 @@ export default class SpreadsheetSelection extends SystemObject {
                 menuItemId,
                 columnOrRowRange.equals(frozenColumnOrRows()), // menuItemDisabled skip if given $columnOrRowRange already frozen
                 historyTokens
+            )
+        );
+    }
+
+    viewportContextMenuItemsColumnOrRowUnFreeze(historyTokens, frozenColumnOrRows, menuItems, menuItemId, history) {
+        const frozen = frozenColumnOrRows();
+
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION] = frozen;
+        historyTokens[SpreadsheetHistoryHashTokens.SELECTION_ACTION] = SpreadsheetColumnOrRowUnFreezeHistoryHashToken.INSTANCE;
+
+        menuItems.push(
+            history.menuItem(
+                this.viewportUnFreezeColumnsRowsText(frozen),
+                menuItemId,
+                !Boolean(frozen), // menuItemDisabled skip if nothing is frozen
+                frozen && historyTokens
             )
         );
     }
@@ -447,6 +475,14 @@ export default class SpreadsheetSelection extends SystemObject {
 
     viewportInsertBefore2Text() {
         SystemObject.throwUnsupportedOperation();
+    }
+
+    viewportUnFreezeColumnsRowsText(columnsRowRange) {
+        return "Un Freeze" + (
+            columnsRowRange ?
+                " " + columnsRowRange :
+                ""
+        );
     }
 
     viewportUnHideText() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1767
- column/row context menu item unfreeze all (clears any frozen column/rows) for columns/rows

- TODO Cypress integration tests to verify unfreezing works, requires rendering to honour frozenColumns/Rows.