### PR TITLE
Replace lost select autocomplete popup id with listbox

### DIFF
--- a/cypress/e2e/Select.spec.js
+++ b/cypress/e2e/Select.spec.js
@@ -120,7 +120,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellRangeSelectButton(DISABLED);
@@ -148,7 +148,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellGotoButton(DISABLED);
@@ -176,7 +176,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellGotoButton(DISABLED);
@@ -221,7 +221,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellGotoButton(DISABLED);
@@ -255,7 +255,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellGotoButton(DISABLED);
@@ -283,7 +283,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)
@@ -319,7 +319,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)
@@ -353,7 +353,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)
@@ -398,7 +398,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("not.exist");
 
             testing.selectCellGotoButton(DISABLED);
@@ -437,7 +437,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)
@@ -474,7 +474,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)
@@ -508,7 +508,7 @@ describe(
             testing.selectAutocompleteTextFieldHelper()
                 .should("not.exist");
 
-            testing.selectAutocompletePopup()
+            testing.selectAutocompletePopupListbox()
                 .should("exist");
 
             testing.selectAutocompletePopupOption(0)

--- a/cypress/e2e/SpreadsheetTesting.js
+++ b/cypress/e2e/SpreadsheetTesting.js
@@ -274,8 +274,13 @@ export default class SpreadsheetTesting {
         return this.getById(SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_HELPER_TEXT_ID);
     }
 
-    selectAutocompletePopup() {
-        return this.getById(SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_POPUP_ID);
+    /**
+     * Originally this selected the div of the popup component which contained all the individual items.
+     * Unfortunately the popup is no longer assigned any id, previously it was an id computed from the AutoComplete id
+     * + a known suffix. The next best is to select the ListBox that holds all the items.
+     */
+    selectAutocompletePopupListbox() {
+        return this.getById(SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_LISTBOX_ID);
     }
 
     selectAutocompletePopupOption(nth) {

--- a/src/spreadsheet/reference/SpreadsheetSelectAutocompleteWidget.js
+++ b/src/spreadsheet/reference/SpreadsheetSelectAutocompleteWidget.js
@@ -46,7 +46,7 @@ export default class SpreadsheetSelectAutocompleteWidget extends SpreadsheetHist
 
     static TEXT_FIELD_HELPER_TEXT_ID = SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_ID + "-helper-text"
 
-    static TEXT_FIELD_POPUP_ID = SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_ID + "-popup"
+    static TEXT_FIELD_LISTBOX_ID = SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_ID + "-listbox"
 
     static TEXT_FIELD_OPTION_ID = SpreadsheetSelectAutocompleteWidget.TEXT_FIELD_ID + "-option-"
 


### PR DESCRIPTION
- Unfortunately the popup component is no longer given an id computed from the AutoComplete.id + a known suffix.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1831
- Autocomplete popup id incorrect making Specs like Select.spec broken