### PR TITLE
settings drawer width increased fixes label wordwrapping

### DIFF
--- a/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
+++ b/src/spreadsheet/settings/SpreadsheetSettingsWidget.js
@@ -80,7 +80,7 @@ const useStyles = theme => ({
     },
     label: {
         fontWeight: 700,
-        width: "125px",
+        width: "175px",
         verticalAlign: "middle",
     },
     value: {
@@ -98,7 +98,7 @@ class SpreadsheetSettingsWidget extends SpreadsheetHistoryAwareStateWidget {
     /**
      * The width of the settings in pixels holding settings and tools.
      */
-    static WIDTH = 500;
+    static WIDTH = 750;
 
     static ID = "settings";
 


### PR DESCRIPTION
- Previous property labels if they were longer than 10ish characters were word wrapping.
- Insufficient width was also causing some value components like sliders with ticks & labels to overlap (horrible)

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1828
- Widen /settings panel probably another 100% so labels dont wrap