### PR TITLE
SpreadsheetViewportWidget: After label update load cells 0 width & he…

### DIFF
--- a/src/spreadsheet/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/SpreadsheetViewportWidget.js
@@ -369,8 +369,6 @@ export default class SpreadsheetViewportWidget extends SpreadsheetHistoryAwareSt
                     this.loadCells(
                         this.state.spreadsheetMetadata.getIgnoringDefaults(SpreadsheetMetadata.VIEWPORT_CELL)
                             .viewport(
-                                0,
-                                0,
                                 viewportElement.offsetWidth - ROW_WIDTH,
                                 viewportElement.offsetHeight - COLUMN_HEIGHT,
                             ),


### PR DESCRIPTION
…ight

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1845
- load viewport uses width=0 height=0 after label update