### PR TITLE
SpreadsheetDelta.labelToReferences() handle ranges and labels

### DIFF
--- a/src/spreadsheet/engine/SpreadsheetDelta.js
+++ b/src/spreadsheet/engine/SpreadsheetDelta.js
@@ -244,17 +244,22 @@ export default class SpreadsheetDelta extends SystemObject {
     }
 
     cellReferenceToLabels() {
+        const labels = this.labels();
         const cellReferenceToLabels = new Map();
 
-        this.labels()
-            .forEach(m => {
-                const key = m.reference().toMapKey();
-                var labels = cellReferenceToLabels.get(key);
-                if(null == labels){
-                    labels = [];
-                    cellReferenceToLabels.set(key, labels);
-                }
-                labels.push(m.label());
+        labels.forEach(
+            m => {
+                m.reference()
+                    .cellMapKeys(labels)
+                    .forEach(key => {
+                        var l = cellReferenceToLabels.get(key);
+                        if(l == null){
+                            l = [];
+                            cellReferenceToLabels.set(key, l);
+                        }
+                        l.push(m.label());
+                        l.sort();
+                    });
             });
 
         return new ImmutableMap(cellReferenceToLabels);

--- a/src/spreadsheet/reference/SpreadsheetCellRange.js
+++ b/src/spreadsheet/reference/SpreadsheetCellRange.js
@@ -128,6 +128,11 @@ export default class SpreadsheetCellRange extends SpreadsheetExpressionReference
         return this.begin().canFreeze();
     }
 
+    cellMapKeys(labels) {
+       return this.values()
+           .map(v => v.toMapKey());
+    }
+
     freezePatch() {
         return {
             "frozen-columns": this.columnOrRange().toString(),

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -224,6 +224,12 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
         };
     }
 
+    cellMapKeys(labels) {
+        return [
+            this.toMapKey()
+        ];
+    }
+
     testCell(cellReference) {
         return this.column().testCell(cellReference) &&
             this.row().testCell(cellReference);

--- a/src/spreadsheet/reference/SpreadsheetExpressionReference.js
+++ b/src/spreadsheet/reference/SpreadsheetExpressionReference.js
@@ -1,4 +1,5 @@
 import SpreadsheetSelection from "./SpreadsheetSelection.js";
+import SystemObject from "../../SystemObject.js";
 
 /**
  * Common base class for cell-range, cell reference and label name.
@@ -8,6 +9,14 @@ export default class SpreadsheetExpressionReference extends SpreadsheetSelection
     // insertBefore not supported by cell or cell range or label
     apiInsertBeforePostUrl(urlPaths) {
         return false;
+    }
+
+    /**
+     * Returns an array of all the keys for this selection. This helps SpreadsheetDelta build cellReferenceToLabel,
+     * particularly a range to labels expanding to multple keys for each cell in the range.
+     */
+    cellMapKeys(labels) {
+        SystemObject.throwUnsupportedOperation();
     }
 
     selectOptionText() {

--- a/src/spreadsheet/reference/SpreadsheetLabelName.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelName.js
@@ -77,6 +77,20 @@ export default class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabe
         return true;
     }
 
+    cellMapKeys(labels) {
+        var keys = [];
+
+        labels.forEach(m => {
+            if(this.equals(m.label())){
+                keys =
+                    m.reference()
+                        .cellMapKeys(labels);
+            }
+        });
+
+        return keys;
+    }
+
     testCell(cellReference) {
         return false;
     }


### PR DESCRIPTION
- labels that point to another label are resolved so the map is label to cell.
- ranges are expanded so each cell in the range also includes the parent label.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1853
- SpreadsheetDelta.cellReferenceToLabels() doesnt handle range or label to label mappings