### PR TITLE
formula text box hide if selection not a cell

### DIFF
--- a/cypress/e2e/Cell.spec.js
+++ b/cypress/e2e/Cell.spec.js
@@ -300,6 +300,9 @@ describe(
                 .should("have.css", "background-color", SELECTED_COLOR);
             testing.row("3")
                 .should("have.css", "background-color", SELECTED_COLOR);
+
+            testing.formulaText()
+                .should('be.hidden');
         });
 
         it("Cell range out of viewport history hash", () => {
@@ -595,6 +598,9 @@ describe(
 
             testing.hash()
                 .should('match', /.*\/.*\/column\/C/);
+
+            testing.formulaText()
+                .should('be.hidden');
         });
 
         it("Cell formula edit then row click", () => {


### PR DESCRIPTION
- editing via a label reference to a cell still works.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1857
- formula text box should be hidden when non cell selected.