### PR TITLE
equals implementation improvements.

### DIFF
--- a/src/Character.js
+++ b/src/Character.js
@@ -35,9 +35,8 @@ export default class Character extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof Character &&
-                this.text() === other.text());
+        return other instanceof Character &&
+                this.text() === other.text();
     }
 
     toString() {

--- a/src/SystemEnum.js
+++ b/src/SystemEnum.js
@@ -89,7 +89,7 @@ export default class SystemEnum extends SystemObject {
     }
 
     equals(other) {
-        return this === other;
+        return other instanceof this.constructor && this.name() === other.name();
     }
 
     toJson() {

--- a/src/SystemObject.js
+++ b/src/SystemObject.js
@@ -117,7 +117,7 @@ export default class SystemObject {
     }
 
     equals(other) {
-        return this === other;
+        return other instanceof this.constructor;
     }
 
     toJSON() {

--- a/src/color/Color.js
+++ b/src/color/Color.js
@@ -35,9 +35,8 @@ export default class Color extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof Color &&
-                this.text() === other.text())
+        return other instanceof Color &&
+                this.text() === other.text()
     }
 
     toString() {

--- a/src/datetime/LocalDate.js
+++ b/src/datetime/LocalDate.js
@@ -32,9 +32,8 @@ export default class LocalDate extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof LocalDate &&
-                this.text() === other.text());
+        return other instanceof LocalDate &&
+            this.text() === other.text();
     }
 
     toString() {

--- a/src/datetime/LocalDateTime.js
+++ b/src/datetime/LocalDateTime.js
@@ -32,9 +32,8 @@ export default class LocalDateTime extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof LocalDateTime &&
-                this.text() === other.text());
+        return other instanceof LocalDateTime &&
+            this.text() === other.text();
     }
 
     toString() {

--- a/src/datetime/LocalTime.js
+++ b/src/datetime/LocalTime.js
@@ -32,9 +32,8 @@ export default class LocalTime extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof LocalTime &&
-                this.text() === other.text());
+        return other instanceof LocalTime &&
+            this.text() === other.text();
     }
 
     toString() {

--- a/src/math/ExpressionNumber.js
+++ b/src/math/ExpressionNumber.js
@@ -31,9 +31,8 @@ export default class ExpressionNumber extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof ExpressionNumber &&
-                this.text() === other.text());
+        return other instanceof ExpressionNumber &&
+            this.text() === other.text();
     }
 
     toString() {

--- a/src/net/EmailAddress.js
+++ b/src/net/EmailAddress.js
@@ -32,9 +32,8 @@ export default class EmailAddress extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof EmailAddress &&
-                this.text() === other.text());
+        return other instanceof EmailAddress &&
+            this.text() === other.text();
     }
 
     toString() {

--- a/src/net/RelativeUrl.js
+++ b/src/net/RelativeUrl.js
@@ -124,10 +124,9 @@ export default class RelativeUrl extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof RelativeUrl &&
+        return other instanceof RelativeUrl &&
                 this.path() === other.path() &&
-                Equality.safeEquals(this.queryParameters(), other.queryParameters()));
+                Equality.safeEquals(this.queryParameters(), other.queryParameters());
     }
 
     toString() {

--- a/src/spreadsheet/SpreadsheetCell.js
+++ b/src/spreadsheet/SpreadsheetCell.js
@@ -176,8 +176,7 @@ export default class SpreadsheetCell extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetCell &&
+        return (other instanceof SpreadsheetCell &&
                 this.reference().equals(other.reference()) &&
                 this.formula().equals(other.formula()) &&
                 Equality.safeEquals(this.style(), other.style()) &&

--- a/src/spreadsheet/SpreadsheetCellFormat.js
+++ b/src/spreadsheet/SpreadsheetCellFormat.js
@@ -31,9 +31,8 @@ export default class SpreadsheetCellFormat extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetCellFormat &&
-                this.pattern() === other.pattern());
+        return other instanceof SpreadsheetCellFormat &&
+            this.pattern() === other.pattern();
     }
 
     toString() {

--- a/src/spreadsheet/SpreadsheetError.js
+++ b/src/spreadsheet/SpreadsheetError.js
@@ -47,9 +47,8 @@ export default class SpreadsheetError extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetError &&
-                this.message() === other.message());
+        return other instanceof SpreadsheetError &&
+            this.message() === other.message();
     }
 
     toString() {

--- a/src/spreadsheet/SpreadsheetExpressionReferenceSimilarities.js
+++ b/src/spreadsheet/SpreadsheetExpressionReferenceSimilarities.js
@@ -78,13 +78,10 @@ export default class SpreadsheetExpressionReferenceSimilarities extends SystemOb
     }
 
     equals(other) {
-        return this === other ||
-            (
-                other instanceof SpreadsheetExpressionReferenceSimilarities &&
-                Equality.safeEquals(this.cellReference(), other.cellReference()) &&
-                Equality.safeEquals(this.label(), other.label()) &&
-                Equality.safeEquals(this.labelMappings(), other.labelMappings())
-            );
+        return other instanceof SpreadsheetExpressionReferenceSimilarities &&
+            Equality.safeEquals(this.cellReference(), other.cellReference()) &&
+            Equality.safeEquals(this.label(), other.label()) &&
+            Equality.safeEquals(this.labelMappings(), other.labelMappings());
     }
 
     toString() {

--- a/src/spreadsheet/SpreadsheetFormula.js
+++ b/src/spreadsheet/SpreadsheetFormula.js
@@ -70,19 +70,14 @@ export default class SpreadsheetFormula extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetFormula &&
-                equals0(this, other));
+        return other instanceof SpreadsheetFormula &&
+            this.text() === other.text() &&
+            Equality.safeEquals(this.value(), other.value());
     }
 
     toString() {
         return JSON.stringify(this.toJson());
     }
-}
-
-function equals0(formula, other) {
-    return formula.text() === other.text() &&
-        Equality.safeEquals(formula.value(), other.value());
 }
 
 function checkText(text) {

--- a/src/spreadsheet/SpreadsheetName.js
+++ b/src/spreadsheet/SpreadsheetName.js
@@ -35,7 +35,8 @@ export default class SpreadsheetName extends SystemObject {
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetName && this.value() === other.value());
+        return other instanceof SpreadsheetName &&
+            this.value() === other.value();
     }
 
     toString() {

--- a/src/spreadsheet/SpreadsheetViewport.js
+++ b/src/spreadsheet/SpreadsheetViewport.js
@@ -96,11 +96,10 @@ export default class SpreadsheetViewport extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetViewport &&
-                this.cellOrLabel().equals(other.cellOrLabel()) &&
-                this.width() === other.width() &&
-                this.height() === other.height());
+        return other instanceof SpreadsheetViewport &&
+            this.cellOrLabel().equals(other.cellOrLabel()) &&
+            this.width() === other.width() &&
+            this.height() === other.height();
     }
 
     toString() {

--- a/src/spreadsheet/engine/SpreadsheetDelta.js
+++ b/src/spreadsheet/engine/SpreadsheetDelta.js
@@ -389,8 +389,7 @@ export default class SpreadsheetDelta extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetDelta &&
+        return other instanceof SpreadsheetDelta &&
                 Equality.safeEquals(this.selection(), other.selection()) &&
                 Equality.safeEquals(this.cells(), other.cells()) &&
                 Equality.safeEquals(this.columns(), other.columns()) &&
@@ -401,8 +400,7 @@ export default class SpreadsheetDelta extends SystemObject {
                 Equality.safeEquals(this.deletedRows(), other.deletedRows()) &&
                 this.columnWidths().equals(other.columnWidths()) &&
                 this.rowHeights().equals(other.rowHeights()) &&
-                Equality.safeEquals(this.window(), other.window())
-            );
+                Equality.safeEquals(this.window(), other.window());
     }
 
     toString() {

--- a/src/spreadsheet/format/SpreadsheetDateFormatPattern.js
+++ b/src/spreadsheet/format/SpreadsheetDateFormatPattern.js
@@ -19,12 +19,6 @@ export default class SpreadsheetDateFormatPattern extends SpreadsheetFormatPatte
     typeName() {
         return SpreadsheetDateFormatPattern.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetDateFormatPattern &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetDateFormatPattern.TYPE_NAME, SpreadsheetDateFormatPattern.fromJson);

--- a/src/spreadsheet/format/SpreadsheetDateParsePatterns.js
+++ b/src/spreadsheet/format/SpreadsheetDateParsePatterns.js
@@ -19,12 +19,6 @@ export default class SpreadsheetDateParsePatterns extends SpreadsheetParsePatter
     typeName() {
         return SpreadsheetDateParsePatterns.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetDateParsePatterns &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetDateParsePatterns.TYPE_NAME, SpreadsheetDateParsePatterns.fromJson);

--- a/src/spreadsheet/format/SpreadsheetDateTimeFormatPattern.js
+++ b/src/spreadsheet/format/SpreadsheetDateTimeFormatPattern.js
@@ -19,12 +19,6 @@ export default class SpreadsheetDateTimeFormatPattern extends SpreadsheetFormatP
     typeName() {
         return SpreadsheetDateTimeFormatPattern.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetDateTimeFormatPattern &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetDateTimeFormatPattern.TYPE_NAME, SpreadsheetDateTimeFormatPattern.fromJson);

--- a/src/spreadsheet/format/SpreadsheetDateTimeParsePatterns.js
+++ b/src/spreadsheet/format/SpreadsheetDateTimeParsePatterns.js
@@ -19,12 +19,6 @@ export default class SpreadsheetDateTimeParsePatterns extends SpreadsheetParsePa
     typeName() {
         return SpreadsheetDateTimeParsePatterns.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetDateTimeParsePatterns &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetDateTimeParsePatterns.TYPE_NAME, SpreadsheetDateTimeParsePatterns.fromJson);

--- a/src/spreadsheet/format/SpreadsheetNumberFormatPattern.js
+++ b/src/spreadsheet/format/SpreadsheetNumberFormatPattern.js
@@ -19,12 +19,6 @@ export default class SpreadsheetNumberFormatPattern extends SpreadsheetFormatPat
     typeName() {
         return SpreadsheetNumberFormatPattern.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetNumberFormatPattern &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetNumberFormatPattern.TYPE_NAME, SpreadsheetNumberFormatPattern.fromJson);

--- a/src/spreadsheet/format/SpreadsheetNumberParsePatterns.js
+++ b/src/spreadsheet/format/SpreadsheetNumberParsePatterns.js
@@ -24,12 +24,6 @@ export default class SpreadsheetNumberParsePatterns extends SpreadsheetParsePatt
     typeName() {
         return SpreadsheetNumberParsePatterns.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetNumberParsePatterns &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetNumberParsePatterns.TYPE_NAME, SpreadsheetNumberParsePatterns.fromJson);

--- a/src/spreadsheet/format/SpreadsheetPattern.js
+++ b/src/spreadsheet/format/SpreadsheetPattern.js
@@ -23,9 +23,8 @@ export default class SpreadsheetPattern extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetPattern &&
-                this.pattern() === other.pattern())
+        return other instanceof this.constructor &&
+                this.pattern() === other.pattern();
     }
 
     toString() {

--- a/src/spreadsheet/format/SpreadsheetText.js
+++ b/src/spreadsheet/format/SpreadsheetText.js
@@ -48,10 +48,9 @@ export default class SpreadsheetText extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetText &&
-                this.color() === other.color() &&
-                this.text() === other.text())
+        return other instanceof SpreadsheetText &&
+                this.color().equals(other.color()) &&
+                this.text() === other.text();
     }
 
     toString() {

--- a/src/spreadsheet/format/SpreadsheetTextFormatPattern.js
+++ b/src/spreadsheet/format/SpreadsheetTextFormatPattern.js
@@ -24,12 +24,6 @@ export default class SpreadsheetTextFormatPattern extends SpreadsheetFormatPatte
     typeName() {
         return SpreadsheetTextFormatPattern.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetTextFormatPattern &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetTextFormatPattern.TYPE_NAME, SpreadsheetTextFormatPattern.fromJson);

--- a/src/spreadsheet/format/SpreadsheetTimeFormatPattern.js
+++ b/src/spreadsheet/format/SpreadsheetTimeFormatPattern.js
@@ -24,12 +24,6 @@ export default class SpreadsheetTimeFormatPattern extends SpreadsheetFormatPatte
     typeName() {
         return SpreadsheetTimeFormatPattern.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetTimeFormatPattern &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetTimeFormatPattern.TYPE_NAME, SpreadsheetTimeFormatPattern.fromJson);

--- a/src/spreadsheet/format/SpreadsheetTimeParsePatterns.js
+++ b/src/spreadsheet/format/SpreadsheetTimeParsePatterns.js
@@ -24,12 +24,6 @@ export default class SpreadsheetTimeParsePatterns extends SpreadsheetParsePatter
     typeName() {
         return SpreadsheetTimeParsePatterns.TYPE_NAME;
     }
-
-    equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetTimeParsePatterns &&
-                this.pattern() === other.pattern())
-    }
 }
 
 SystemObject.register(SpreadsheetTimeParsePatterns.TYPE_NAME, SpreadsheetTimeParsePatterns.fromJson);

--- a/src/spreadsheet/history/SpreadsheetCellClearHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetCellClearHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetCellClearHistoryHashToken extends SpreadsheetCel
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.clearSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetCellClearHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetCellDeleteHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetCellDeleteHistoryHashToken.js
@@ -25,8 +25,4 @@ export default class SpreadsheetCellDeleteHistoryHashToken extends SpreadsheetCe
     labelMappingWidget(widget) {
         widget.deleteLabelMapping();
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetCellDeleteHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetCellFreezeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetCellFreezeHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetCellFreezeHistoryHashToken extends SpreadsheetCe
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.freezeSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetCellFreezeHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetCellMenuHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetCellMenuHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetCellMenuHistoryHashToken extends SpreadsheetCell
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.showContextMenu(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetCellMenuHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetCellUnFreezeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetCellUnFreezeHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetCellUnFreezeHistoryHashToken extends Spreadsheet
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.unFreezeSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetCellUnFreezeHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowClearHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowClearHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetColumnOrRowClearHistoryHashToken extends Spreads
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.clearSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowClearHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowDeleteHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowDeleteHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetColumnOrRowDeleteHistoryHashToken extends Spread
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.deleteSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowDeleteHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowFreezeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowFreezeHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetColumnOrRowFreezeHistoryHashToken extends Spread
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.freezeSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowFreezeHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowInsertAfterHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowInsertAfterHistoryHashToken.js
@@ -25,6 +25,7 @@ export default class SpreadsheetColumnOrRowInsertAfterHistoryHashToken extends S
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowInsertAfterHistoryHashToken && this.count() === other.count());
+        return super.equals(other) &&
+            this.count() === other.count();
     }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowInsertBeforeHistoryHashToken.js
@@ -21,6 +21,7 @@ export default class SpreadsheetColumnOrRowInsertBeforeHistoryHashToken extends 
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowInsertBeforeHistoryHashToken && this.count() === other.count());
+        return super.equals(other) &&
+            this.count() === other.count();
     }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowMenuHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowMenuHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetColumnOrRowMenuHistoryHashToken extends Spreadsh
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.showContextMenu(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowMenuHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowSaveHistoryHashToken.js
@@ -43,6 +43,8 @@ export default class SpreadsheetColumnOrRowSaveHistoryHashToken extends Spreadsh
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowSaveHistoryHashToken && this.property() === other.property() && Equality.safeEquals(this.value, other.value()));
+        return super.equals(other) &&
+            this.property() === other.property() &&
+            Equality.safeEquals(this.value, other.value());
     }
 }

--- a/src/spreadsheet/history/SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetColumnOrRowUnFreezeHistoryHashToken.js
@@ -21,8 +21,4 @@ export default class SpreadsheetColumnOrRowUnFreezeHistoryHashToken extends Spre
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         viewportWidget.unFreezeSelection(viewportSelection);
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnOrRowUnFreezeHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetFormulaEditHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetFormulaEditHistoryHashToken.js
@@ -29,7 +29,8 @@ export default class SpreadsheetFormulaEditHistoryHashToken extends SpreadsheetF
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetFormulaEditHistoryHashToken && this.formulaText() === other.formulaText());
+        return super.equals(other) &&
+            this.formulaText() === other.formulaText();
     }
 
     toString() {

--- a/src/spreadsheet/history/SpreadsheetFormulaSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetFormulaSaveHistoryHashToken.js
@@ -26,7 +26,8 @@ export default class SpreadsheetFormulaSaveHistoryHashToken extends SpreadsheetF
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetFormulaSaveHistoryHashToken && this.formulaText() === other.formulaText());
+        return super.equals(other) &&
+            this.formulaText() === other.formulaText();
     }
 
     toString() {

--- a/src/spreadsheet/history/SpreadsheetHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHashToken.js
@@ -3,7 +3,7 @@
  */
 import SystemObject from "../../SystemObject.js";
 
-export default class SpreadsheetHistoryHashToken {
+export default class SpreadsheetHistoryHashToken extends SystemObject {
 
     onViewportSelectionAction(viewportSelection, viewportWidget) {
         SystemObject.throwUnsupportedOperation();

--- a/src/spreadsheet/history/SpreadsheetLabelMappingDeleteHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetLabelMappingDeleteHistoryHashToken.js
@@ -28,8 +28,4 @@ export default class SpreadsheetLabelMappingDeleteHistoryHashToken extends Sprea
     execute(widget) {
         widget.deleteLabelMapping(this.label());
     }
-
-    equals(other) {
-        return this === other || (other instanceof SpreadsheetLabelMappingDeleteHistoryHashToken);
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetLabelMappingEditHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetLabelMappingEditHistoryHashToken.js
@@ -29,7 +29,7 @@ export default class SpreadsheetLabelMappingEditHistoryHashToken extends Spreads
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetLabelMappingEditHistoryHashToken && this.label().equals(other.label()));
+        return super.equals(other) &&
+            this.label().equals(other.label());
     }
 }

--- a/src/spreadsheet/history/SpreadsheetLabelMappingSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetLabelMappingSaveHistoryHashToken.js
@@ -47,11 +47,9 @@ export default class SpreadsheetLabelMappingSaveHistoryHashToken extends Spreads
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetLabelMappingSaveHistoryHashToken &&
+        return super.equals(other) &&
                 this.label().equals(other.label()) &&
                 this.newLabel().equals(other.newLabel()) &&
-                this.reference().equals(other.reference())
-            );
+                this.reference().equals(other.reference());
     }
 }

--- a/src/spreadsheet/history/SpreadsheetNameEditHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetNameEditHistoryHashToken.js
@@ -15,8 +15,4 @@ export default class SpreadsheetNameEditHistoryHashToken extends SpreadsheetName
     execute(spreadsheetNameWidget) {
         // nop
     }
-
-    equals(other) {
-        return this === other || other instanceof SpreadsheetNameEditHistoryHashToken;
-    }
 }

--- a/src/spreadsheet/history/SpreadsheetNameSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetNameSaveHistoryHashToken.js
@@ -31,6 +31,7 @@ export default class SpreadsheetNameSaveHistoryHashToken extends SpreadsheetName
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetNameSaveHistoryHashToken && Equality.safeEquals(this.value(), other.value()));
+        return super.equals(other) &&
+            Equality.safeEquals(this.value(), other.value());
     }
 }

--- a/src/spreadsheet/history/SpreadsheetSettingsSaveHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetSettingsSaveHistoryHashToken.js
@@ -47,7 +47,8 @@ export default class SpreadsheetSettingsSaveHistoryHashToken extends Spreadsheet
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetSettingsSaveHistoryHashToken && this.property() === other.property() && Equality.safeEquals(this.value(), other.value()));
+        return super.equals(other) &&
+            this.property() === other.property() &&
+            Equality.safeEquals(this.value(), other.value());
     }
 }

--- a/src/spreadsheet/history/SpreadsheetSettingsSelectHistoryHashToken.js
+++ b/src/spreadsheet/history/SpreadsheetSettingsSelectHistoryHashToken.js
@@ -37,6 +37,7 @@ export default class SpreadsheetSettingsSelectHistoryHashToken extends Spreadshe
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetSettingsSelectHistoryHashToken && Equality.safeEquals(this.item(), other.item()));
+        return super.equals(other) &&
+            Equality.safeEquals(this.item(), other.item());
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetCellRange.js
+++ b/src/spreadsheet/reference/SpreadsheetCellRange.js
@@ -299,11 +299,15 @@ export default class SpreadsheetCellRange extends SpreadsheetExpressionReference
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetCellRange && this.begin().equals(other.begin()) && this.end().equals(other.end()));
+        return super.equals(other) &&
+            this.begin().equals(other.begin()) &&
+            this.end().equals(other.end());
     }
 
     equalsIgnoringKind(other) {
-        return this === other || (other instanceof SpreadsheetCellRange && this.begin().equalsIgnoringKind(other.begin()) && this.end().equalsIgnoringKind(other.end()));
+        return super.equals(other) &&
+            this.begin().equalsIgnoringKind(other.begin()) &&
+            this.end().equalsIgnoringKind(other.end());
     }
 }
 

--- a/src/spreadsheet/reference/SpreadsheetCellReference.js
+++ b/src/spreadsheet/reference/SpreadsheetCellReference.js
@@ -335,11 +335,15 @@ export default class SpreadsheetCellReference extends SpreadsheetCellReferenceOr
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetCellReference && this.column().equals(other.column()) && this.row().equals(other.row()));
+        return super.equals(other) &&
+            this.column().equals(other.column()) &&
+            this.row().equals(other.row());
     }
 
     equalsIgnoringKind(other) {
-        return this === other || (other instanceof SpreadsheetCellReference && this.column().equalsIgnoringKind(other.column()) && this.row().equalsIgnoringKind(other.row()));
+        return super.equals(other) &&
+            this.column().equalsIgnoringKind(other.column()) &&
+            this.row().equalsIgnoringKind(other.row());
     }
 
     toString() {

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRow.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRow.js
@@ -18,6 +18,8 @@ export default class SpreadsheetColumnOrRow extends SystemObject {
     }
 
     equals(other) {
-        return this === other || (other instanceof this.constructor && this.reference().equals(other.reference()) && this.hidden() === other.hidden());
+        return super.equals(other) &&
+            this.reference().equals(other.reference()) &&
+            this.hidden() === other.hidden();
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnOrRowReference.js
@@ -138,10 +138,12 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
     }
 
     equals(other) {
-        return this === other || (other instanceof this.constructor && this.kind().equals(other.kind()) && this.value() === other.value());
+        return super.equals(other) &&
+            this.kind().equals(other.kind()) &&
+            this.value() === other.value();
     }
 
     equalsIgnoringKind(other) {
-        return this === other || (other instanceof this.constructor && this.value() === other.value());
+        return super.equals(other) && this.value() === other.value();
     }
 }

--- a/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetColumnReferenceRange.js
@@ -274,11 +274,15 @@ export default class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOr
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetColumnReferenceRange && this.begin().equals(other.begin()) && this.end().equals(other.end()));
+        return super.equals(other) &&
+            this.begin().equals(other.begin()) &&
+            this.end().equals(other.end());
     }
 
     equalsIgnoringKind(other) {
-        return this === other || (other instanceof SpreadsheetColumnReferenceRange && this.begin().equalsIgnoringKind(other.begin()) && this.end().equalsIgnoringKind(other.end()));
+        return super.equals(other) &&
+            this.begin().equalsIgnoringKind(other.begin()) &&
+            this.end().equalsIgnoringKind(other.end());
     }
 }
 

--- a/src/spreadsheet/reference/SpreadsheetLabelMapping.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelMapping.js
@@ -56,7 +56,9 @@ export default class SpreadsheetLabelMapping extends SystemObject {
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetLabelMapping && this.label().equals(other.label()) && this.reference().equals(other.reference()));
+        return other instanceof SpreadsheetLabelMapping &&
+            this.label().equals(other.label()) &&
+            this.reference().equals(other.reference());
     }
 
     toString() {

--- a/src/spreadsheet/reference/SpreadsheetLabelName.js
+++ b/src/spreadsheet/reference/SpreadsheetLabelName.js
@@ -153,7 +153,8 @@ export default class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabe
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetLabelName && this.value().toLocaleLowerCase() === other.value().toLocaleLowerCase());
+        return other instanceof SpreadsheetLabelName &&
+            this.value().toLocaleLowerCase() === other.value().toLocaleLowerCase();
     }
 
     equalsIgnoringKind(other) {

--- a/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
+++ b/src/spreadsheet/reference/SpreadsheetRowReferenceRange.js
@@ -274,11 +274,15 @@ export default class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRow
     }
 
     equals(other) {
-        return this === other || (other instanceof SpreadsheetRowReferenceRange && this.begin().equals(other.begin()) && this.end().equals(other.end()));
+        return super.equals(other) &&
+            this.begin().equals(other.begin()) &&
+            this.end().equals(other.end());
     }
 
     equalsIgnoringKind(other) {
-        return this === other || (other instanceof SpreadsheetRowReferenceRange && this.begin().equalsIgnoringKind(other.begin()) && this.end().equalsIgnoringKind(other.end()));
+        return super.equals(other) &&
+            this.begin().equalsIgnoringKind(other.begin()) &&
+            this.end().equalsIgnoringKind(other.end());
     }
 }
 

--- a/src/spreadsheet/reference/SpreadsheetViewportSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetViewportSelection.js
@@ -114,12 +114,10 @@ export default class SpreadsheetViewportSelection extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetViewportSelection &&
+        return other instanceof SpreadsheetViewportSelection &&
                 this.selection().equals(other.selection()) &&
                 Equality.safeEquals(this.anchor(), other.anchor()) &&
-                Equality.safeEquals(this.navigation(), other.navigation())
-            );
+                Equality.safeEquals(this.navigation(), other.navigation());
     }
 
     toString() {

--- a/src/spreadsheet/server/format/SpreadsheetFormatRequest.js
+++ b/src/spreadsheet/server/format/SpreadsheetFormatRequest.js
@@ -50,11 +50,9 @@ export default class SpreadsheetFormatRequest extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetFormatRequest &&
+        return other instanceof SpreadsheetFormatRequest &&
                 Equality.safeEquals(this.value(), other.value()) &&
-                Equality.safeEquals(this.pattern(), other.pattern())
-            );
+                Equality.safeEquals(this.pattern(), other.pattern());
     }
 
     toString() {

--- a/src/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.js
+++ b/src/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.js
@@ -15,10 +15,6 @@ export default class SpreadsheetLocaleDefaultDateTimeFormat extends SystemObject
         return SpreadsheetLocaleDefaultDateTimeFormat.INSTANCE;
     }
 
-    equals(other) {
-        return this === other;
-    }
-
     toJson() {
         return 1;
     }

--- a/src/spreadsheet/server/format/SpreadsheetMultiFormatRequest.js
+++ b/src/spreadsheet/server/format/SpreadsheetMultiFormatRequest.js
@@ -39,10 +39,8 @@ export default class SpreadsheetMultiFormatRequest extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetMultiFormatRequest &&
-                Equality.safeEquals(this.requests(), other.requests())
-            );
+        return other instanceof SpreadsheetMultiFormatRequest &&
+                Equality.safeEquals(this.requests(), other.requests());
     }
 
     toString() {

--- a/src/spreadsheet/server/format/SpreadsheetMultiFormatResponse.js
+++ b/src/spreadsheet/server/format/SpreadsheetMultiFormatResponse.js
@@ -33,10 +33,8 @@ export default class SpreadsheetMultiFormatResponse extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetMultiFormatResponse &&
-                Equality.safeEquals(this.responses(), other.responses())
-            );
+        return other instanceof SpreadsheetMultiFormatResponse &&
+                Equality.safeEquals(this.responses(), other.responses());
     }
 
     toString() {

--- a/src/spreadsheet/server/parse/SpreadsheetMultiParseRequest.js
+++ b/src/spreadsheet/server/parse/SpreadsheetMultiParseRequest.js
@@ -40,10 +40,8 @@ export default class SpreadsheetMultiParseRequest extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetMultiParseRequest &&
-                Equality.safeEquals(this.requests(), other.requests())
-            );
+        return other instanceof SpreadsheetMultiParseRequest &&
+            Equality.safeEquals(this.requests(), other.requests());
     }
 
     toString() {

--- a/src/spreadsheet/server/parse/SpreadsheetParseRequest.js
+++ b/src/spreadsheet/server/parse/SpreadsheetParseRequest.js
@@ -41,11 +41,9 @@ export default class SpreadsheetParseRequest extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof SpreadsheetParseRequest &&
-                this.text() === other.text() &&
-                this.parser() === other.parser()
-            );
+        return other instanceof SpreadsheetParseRequest &&
+            this.text() === other.text() &&
+            this.parser() === other.parser();
     }
 
     toString() {

--- a/src/text/FontFamily.js
+++ b/src/text/FontFamily.js
@@ -31,9 +31,8 @@ export default class FontFamily extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof FontFamily &&
-                this.name() === other.name());
+        return other instanceof FontFamily &&
+            this.name() === other.name();
     }
 
     toString() {

--- a/src/text/FontSize.js
+++ b/src/text/FontSize.js
@@ -34,9 +34,8 @@ export default class FontSize extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof FontSize &&
-                this.value() === other.value());
+        return other instanceof FontSize &&
+            this.value() === other.value();
     }
 
     toString() {

--- a/src/text/FontWeight.js
+++ b/src/text/FontWeight.js
@@ -34,9 +34,8 @@ export default class FontWeight extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof FontWeight &&
-                this.value() === other.value());
+        return other instanceof FontWeight &&
+            this.value() === other.value();
     }
 
     toString() {

--- a/src/text/NoneLength.js
+++ b/src/text/NoneLength.js
@@ -53,9 +53,8 @@ export default class NoneLength extends Length {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof NoneLength &&
-                this.value() === other.value());
+        return other instanceof NoneLength &&
+            this.value() === other.value();
     }
 
     toString() {

--- a/src/text/PixelLength.js
+++ b/src/text/PixelLength.js
@@ -51,9 +51,8 @@ export default class PixelLength extends Length {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof PixelLength &&
-                this.value() === other.value());
+        return other instanceof PixelLength &&
+            this.value() === other.value();
     }
 
     toString() {

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -34,9 +34,8 @@ export default class Text extends TextLeafNode {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof Text &&
-                this.value() === other.value());
+        return other instanceof Text &&
+            this.value() === other.value();
     }
 }
 

--- a/src/text/TextPlaceholderNode.js
+++ b/src/text/TextPlaceholderNode.js
@@ -32,9 +32,8 @@ export default class TextPlaceholderNode extends TextLeafNode {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof TextPlaceholderNode &&
-                this.value() === other.value());
+        return other instanceof TextPlaceholderNode &&
+            this.value() === other.value();
     }
 }
 

--- a/src/text/TextStyle.js
+++ b/src/text/TextStyle.js
@@ -748,7 +748,8 @@ export default class TextStyle extends SystemObject {
     }
 
     equals(other) {
-        return this === other || (other instanceof TextStyle && toJsonString(this) === toJsonString(other));
+        return other instanceof TextStyle &&
+            toJsonString(this) === toJsonString(other);
     }
 
     toString() {

--- a/src/text/TextStyleNameNode.js
+++ b/src/text/TextStyleNameNode.js
@@ -50,9 +50,8 @@ export default class TextStyleNameNode extends TextNode {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof TextStyleNameNode &&
-                this.styleName() === other.styleName() &&
-                Equality.safeEquals(this.children(), other.children()));
+        return other instanceof TextStyleNameNode &&
+            this.styleName() === other.styleName() &&
+            Equality.safeEquals(this.children(), other.children());
     }
 }

--- a/src/text/TextStyleNode.js
+++ b/src/text/TextStyleNode.js
@@ -55,9 +55,8 @@ export default class TextStyleNode extends TextNode {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof TextStyleNode &&
-                this.styles().equals(other.styles()) &&
-                Equality.safeEquals(this.children(), other.children()));
+        return other instanceof TextStyleNode &&
+            this.styles().equals(other.styles()) &&
+            Equality.safeEquals(this.children(), other.children());
     }
 }

--- a/src/util/ImmutableMap.js
+++ b/src/util/ImmutableMap.js
@@ -112,7 +112,8 @@ export default class ImmutableMap {
     }
 
     equals(other) {
-        return this === other || (other instanceof ImmutableMap && equals0(this.map, other.map));
+        return other instanceof ImmutableMap &&
+            equals0(this.map, other.map);
     }
 
     toString() {

--- a/src/util/Locale.js
+++ b/src/util/Locale.js
@@ -34,9 +34,8 @@ export default class Locale extends SystemObject {
     }
 
     equals(other) {
-        return this === other ||
-            (other instanceof Locale &&
-                this.text() === other.text());
+        return other instanceof Locale &&
+            this.text() === other.text();
     }
 
     toString() {


### PR DESCRIPTION
- SystemObject.equals() returns true if other is the same type.
- removed pointless `this == other` in many equals methods.
- SystemEnum.equals returns equal if the other enum is the same type and has the same name.
- SpreadsheetHistoryHashToken now extends SystemObject.
- SpreadsheetPattern.equals() returns true if other is same type and patterns are equal.