### PR TITLE
Made regexp and patterns exact in e2e tests

### DIFF
--- a/cypress/e2e/Cell.spec.js
+++ b/cypress/e2e/Cell.spec.js
@@ -54,7 +54,7 @@ describe(
                 .type("{selectall}=1+2+3{enter}");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/B2\/formula/);
+                .should("match", /^#\/.*\/Untitled\/cell\/B2\/formula$/);
 
             testing.cellFormattedTextCheck(B2, "6.");
         });
@@ -115,7 +115,7 @@ describe(
             testing.hashAppend("/cell/" + LABEL);
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
         });
 
         it("Cell click should have focus", () => {
@@ -144,7 +144,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/B3/);
+                .should("match", /^#\/.*\/.*\/cell\/B3$/);
 
             testing.cell(B3)
                 .type("{rightarrow}");
@@ -152,7 +152,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/C3/);
+                .should("match", /^#\/.*\/.*\/cell\/C3$/);
 
             testing.cell(C3)
                 .type("{uparrow}");
@@ -160,7 +160,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/C2/);
+                .should("match", /^#\/.*\/.*\/cell\/C2$/);
 
             testing.cell(C2)
                 .type("{downarrow}");
@@ -168,7 +168,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/C3/);
+                .should("match", /^#\/.*\/.*\/cell\/C3$/);
         });
 
         it("Cell click and hit ENTER gives formula text focus", () => {
@@ -178,7 +178,7 @@ describe(
                 .type("{enter}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/A3\/formula/);
+                .should("match", /^#\/.*\/.*\/cell\/A3\/formula$/);
 
             testing.formulaText()
                 .should("have.focus");
@@ -191,7 +191,7 @@ describe(
                 .type("{esc}");
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         it("Cell outside viewport", () => {
@@ -287,7 +287,7 @@ describe(
             testing.hashAppend("/cell/B2:C3");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/B2:C3/);
+                .should("match", /^#\/.*\/.*\/cell\/B2:C3$/);
 
             testing.historyWait();
 
@@ -309,7 +309,7 @@ describe(
             testing.hashAppend("/cell/X2:Y3");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/X2:Y3/);
+                .should("match", /^#\/.*\/.*\/cell\/X2:Y3$/);
 
             testing.historyWait();
 
@@ -328,7 +328,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -338,7 +338,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/C4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/C4:E5\/bottom-right$/);
 
             testing.cell("C4")
                 .should("have.focus");
@@ -360,7 +360,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -375,7 +375,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/E4:F5/);
+                .should("match", /^#\/.*\/.*\/cell\/E4:F5\/bottom-left$/);
 
             testing.cell("F4")
                 .should("have.focus");
@@ -395,7 +395,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -412,7 +412,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/E4:F5/);
+                .should("match", /^#\/.*\/.*\/cell\/E4:F5\/bottom-left$/);
 
             testing.cell("F4")
                 .should("have.focus")
@@ -421,7 +421,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/E4:G5/);
+                .should("match", /^#\/.*\/.*\/cell\/E4:G5\/bottom-left$/);
 
             testing.cell("G4")
                 .should("have.focus");
@@ -443,7 +443,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -453,7 +453,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D3:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D3:E5\/bottom-right$/);
 
             testing.cell("D3")
                 .should("have.focus");
@@ -475,7 +475,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -484,14 +484,14 @@ describe(
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D5:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D5:E5\/bottom-right$/);
 
             testing.cell("D5")
                 .should("have.focus")
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D5:E6/);
+                .should("match", /^#\/.*\/.*\/cell\/D5:E6\/top-right$/);
 
             testing.cell("D6")
                 .should("have.focus");
@@ -511,7 +511,7 @@ describe(
             testing.hashAppend("/cell/D4:E5");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D4:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D4:E5$/);
 
             testing.historyWait();
 
@@ -520,21 +520,21 @@ describe(
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D5:E5/);
+                .should("match", /^#\/.*\/.*\/cell\/D5:E5\/bottom-right$/);
 
             testing.cell("D5")
                 .should("have.focus")
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D5:E6/);
+                .should("match", /^#\/.*\/.*\/cell\/D5:E6\/top-right$/);
 
             testing.cell("D6")
                 .should("have.focus")
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/D5:E7/);
+                .should("match", /^#\/.*\/.*\/cell\/D5:E7\/top-right$/);
 
             testing.cell("D7")
                 .should("have.focus")
@@ -563,7 +563,7 @@ describe(
             testing.hashAppendWithoutCheck("/delete");
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck(B2, "");
 
@@ -581,7 +581,7 @@ describe(
             testing.hashAppendWithoutCheck(":C3/delete");
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck("A1", "NotDeleted");
             testing.cellFormattedTextCheck(B2, "");
@@ -597,7 +597,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/C/);
+                .should("match", /^#\/.*\/.*\/column\/C$/);
 
             testing.formulaText()
                 .should('be.hidden');
@@ -610,20 +610,20 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/3/);
+                .should("match", /^#\/.*\/.*\/row\/3$/);
         });
 
         it("Cell formula edit different formula edit", () => {
             testing.hashAppend("/cell/B2/formula");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/B2\/formula/);
+                .should("match", /^#\/.*\/.*\/cell\/B2\/formula$/);
 
             testing.hashAppend("/cell/C3/formula"); // invalid removes cell from hash
             testing.hashAppend("/cell/C3/formula");
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/C3/);
+                .should("match", /^#\/.*\/.*\/cell\/B2\/formula$/);
         });
 
         // context menu.................................................................................................
@@ -639,28 +639,28 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cell")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/delete/)
+                .and("match", /#\/.*\/.*\/cell\/A1\/delete$/)
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete column")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A\/delete/);
+                .and("match", /#\/.*\/.*\/column\/A\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete row")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1\/delete/);
+                .and("match", /#\/.*\/.*\/row\/1\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze A1")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze A1")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1\/unfreeze$/);
         });
 
         it("hash /cell/B2/menu", () => {
@@ -674,29 +674,29 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cell")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/B2\/delete/)
+                .and("match", /#\/.*\/.*\/cell\/B2\/delete$/)
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete column")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/delete/);
+                .and("match", /#\/.*\/.*\/column\/B\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete row")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/delete/);
+                .and("match", /#\/.*\/.*\/row\/2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze B2")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/B2\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/B2\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze B2")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/B2\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/B2\/unfreeze$/);
         });
 
         it("hash /cell/A1:B2/menu", () => {
@@ -710,28 +710,28 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cells")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B1\/delete/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B1\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete columns")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:B\/delete/);
+                .and("match", /#\/.*\/.*\/column\/A:B\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete row")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1\/delete/);
+                .and("match", /#\/.*\/.*\/row\/1\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze A1:B1")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B1\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B1\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze A1:B1")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B1\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B1\/unfreeze$/);
         });
 
         it("hash /cell/A1:A2/menu", () => {
@@ -745,28 +745,28 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cells")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:A2\/delete/);
+                .and("match", /#\/.*\/.*\/cell\/A1:A2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete column")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A\/delete/);
+                .and("match", /#\/.*\/.*\/column\/A\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete rows")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:2\/delete/);
+                .and("match", /#\/.*\/.*\/row\/1:2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze A1:A2")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:A2\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:A2\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze A1:A2")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:A2\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:A2\/unfreeze$/);
         });
 
         it("hash /cell/A1:B2/menu", () => {
@@ -780,28 +780,28 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cells")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B2\/delete/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete columns")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:B\/delete/);
+                .and("match", /#\/.*\/.*\/column\/A:B\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete rows")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:2\/delete/);
+                .and("match", /#\/.*\/.*\/row\/1:2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze A1:B2")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B2\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B2\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze A1:B2")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1:B2\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1:B2\/unfreeze$/);
         });
 
         it("hash /cell/B2:C3/menu", () => {
@@ -816,20 +816,20 @@ describe(
                 .should("have.text", "Freeze B2:C3")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/B2:C3\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/B2:C3\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze B2:C3")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/B2:C3\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/B2:C3\/unfreeze$/);
         });
 
         it("Cell context menu A1", () => {
             testing.contextMenu(A1.viewportId());
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/A1\/menu/);
+                .should("match", /^#\/.*\/.*\/cell\/A1\/menu$/);
 
             testing.viewportContextMenu()
                 .should("be.visible")
@@ -839,28 +839,28 @@ describe(
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.text", "Delete cell")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/delete/);
+                .and("match", /#\/.*\/.*\/cell\/A1\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_COLUMN_ID)
                 .should("have.text", "Delete column")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A\/delete/);
+                .and("match", /#\/.*\/.*\/column\/A\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_ROW_ID)
                 .should("have.text", "Delete row")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1\/delete/);
+                .and("match", /#\/.*\/.*\/row\/1\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_ID)
                 .should("have.text", "Freeze A1")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/freeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID)
                 .should("have.text", "Un Freeze A1")
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/cell\/A1\/unfreeze/);
+                .and("match", /#\/.*\/.*\/cell\/A1\/unfreeze$/);
         });
 
         // Freeze.......................................................................................................

--- a/cypress/e2e/Column.spec.js
+++ b/cypress/e2e/Column.spec.js
@@ -38,7 +38,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/B/);
+                .should("match", /^#\/.*\/.*\/column\/B$/);
 
             testing.column("B")
                 .should("have.focus")
@@ -54,7 +54,7 @@ describe(
                 .type("{rightarrow}")
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/C/);
+                .should("match", /^#\/.*\/.*\/column\/C$/);
 
             testing.column("C")
                 .should("have.focus")
@@ -90,7 +90,7 @@ describe(
                 .type("{shift+leftarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/D:E/);
+                .should("match", /^#\/.*\/.*\/column\/D:E\/right$/);
 
             testing.column("D")
                 .should("have.focus")
@@ -110,7 +110,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/E:F/);
+                .should("match", /^#\/.*\/.*\/column\/E:F\/left$/);
 
             testing.column("F")
                 .should("have.focus")
@@ -135,7 +135,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/C:F\/right/);
+                .should("match", /^#\/.*\/.*\/column\/C:F\/right$/);
 
             testing.column("C")
                 .should("have.focus")
@@ -156,15 +156,14 @@ describe(
             testing.column("F")
                 .type("{shift+rightarrow}");
 
-            testing.historyWait();
+            testing.hash()
+                .should("match", /^#\/.*\/.*\/column\/F:G\/left$/);
 
             testing.column("G")
                 .type("{shift+rightarrow}");
 
-            testing.historyWait();
-
             testing.hash()
-                .should('match', /.*\/.*\/column\/F:H\/left/);
+                .should("match", /^#\/.*\/.*\/column\/F:H\/left$/);
 
             testing.column("H")
                 .should("have.focus")
@@ -190,7 +189,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck("D5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -209,7 +208,7 @@ describe(
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck("C5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -228,7 +227,7 @@ describe(
             testing.hashAppendWithoutCheck("/insert-after/1");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/B/);
+                .should("match", /^#\/.*\/.*\/column\/B$/);
 
             testing.cellFormattedTextCheck("F5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -245,7 +244,7 @@ describe(
             testing.hashAppendWithoutCheck(":C/insert-after/2");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/B:C/);
+                .should("match", /^#\/.*\/.*\/column\/B:C$/);
 
             testing.cellFormattedTextCheck("G5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -264,7 +263,7 @@ describe(
             testing.hashAppendWithoutCheck("/insert-before/1");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/C/);
+                .should("match", /^#\/.*\/.*\/column\/C$/);
 
             testing.cellFormattedTextCheck("F5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -281,7 +280,7 @@ describe(
             testing.hashAppendWithoutCheck(":C/insert-before/2");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/D:E/);
+                .should("match", /^#\/.*\/.*\/column\/D:E$/);
 
             testing.cellFormattedTextCheck("G5", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -296,7 +295,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/A1/);
+                .should("match", /^#\/.*\/.*\/cell\/A1$/);
         });
 
         // column context menu...........................................................................................
@@ -314,7 +313,7 @@ describe(
             testing.contextMenu(C.viewportId());
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/C\/menu/);
+                .should("match", /^#\/.*\/.*\/column\/C\/menu$/);
 
             testing.viewportContextMenu()
                 .should("be.visible")
@@ -332,43 +331,43 @@ describe(
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_CLEAR_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/clear/);
+                .and("match", /#\/.*\/.*\/column\/B\/clear$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/delete/);
+                .and("match", /#\/.*\/.*\/column\/B\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/insert-after\/1/);
+                .and("match", /#\/.*\/.*\/column\/B\/insert-after\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/insert-after\/2/);
+                .and("match", /#\/.*\/.*\/column\/B\/insert-after\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/insert-before\/1/);
+                .and("match", /#\/.*\/.*\/column\/B\/insert-before\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/insert-before\/2/);
+                .and("match", /#\/.*\/.*\/column\/B\/insert-before\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:B\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A:B\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:C\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A:C\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B\/hidden\/true/);
+                .and("match", /#\/.*\/.*\/column\/B\/hidden\/true$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
@@ -383,43 +382,43 @@ describe(
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_CLEAR_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/clear/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/clear$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/delete/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/insert-after\/1/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/insert-after\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/insert-after\/2/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/insert-after\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/insert-before\/1/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/insert-before\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/insert-before\/2/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/insert-before\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:B\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A:B\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/A:C\/freeze/);
+                .and("match", /#\/.*\/.*\/column\/A:C\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/column\/B:C\/hidden\/true/);
+                .and("match", /#\/.*\/.*\/column\/B:C\/hidden\/true$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
@@ -459,7 +458,7 @@ describe(
                 .type("{shift+rightarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/B:C\/left/);
+                .should("match", /^#\/.*\/.*\/column\/B:C\/left$/);
 
             testing.contextMenu(B.viewportId());
 
@@ -513,7 +512,7 @@ describe(
                 .type("{shift+rightarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/column\/B:C\/left/);
+                .should("match", /^#\/.*\/.*\/column\/B:C\/left$/);
 
             testing.contextMenu(B.viewportId());
 
@@ -623,7 +622,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/C/);
+                .should("match", /^#\/.*\/Untitled\/column\/C$/);
 
             testing.contextMenu(C.viewportId());
 
@@ -639,7 +638,7 @@ describe(
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/E/);
+                .should("match", /^#\/.*\/Untitled\/column\/E$/);
 
             testing.cellFormattedTextCheck("E3", "Moved");
             testing.cellFormattedTextCheck(C3, "");
@@ -652,7 +651,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/C/);
+                .should("match", /^#\/.*\/Untitled\/column\/C$/);
 
             testing.contextMenu(C.viewportId());
 
@@ -668,7 +667,7 @@ describe(
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/D/);
+                .should("match", /^#\/.*\/Untitled\/column\/D$/);
 
             testing.cellFormattedTextCheck("D3", "Moved");
             testing.cellFormattedTextCheck(C3, "");
@@ -682,7 +681,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/B/);
+                .should("match", /^#\/.*\/Untitled\/column\/B$/);
 
             testing.contextMenu(B.viewportId());
 
@@ -698,7 +697,7 @@ describe(
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/B/);
+                .should("match", /^#\/.*\/Untitled\/column\/B$/);
 
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("D3", "Moved");
@@ -713,7 +712,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/B/);
+                .should("match", /^#\/.*\/Untitled\/column\/B$/);
 
             testing.contextMenu(B.viewportId());
 
@@ -729,7 +728,7 @@ describe(
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/B/);
+                .should("match", /^#\/.*\/Untitled\/column\/B$/);
 
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("E3", "Moved");
@@ -757,7 +756,7 @@ describe(
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck(A1, "Before");
             testing.get(B2.viewportId())
@@ -792,7 +791,7 @@ describe(
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck(A1, "Before");
             testing.get(B2.viewportId())
@@ -819,14 +818,14 @@ describe(
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.hashAppend("/column/B");
 
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         it("Attempt to history hash select cell in hidden column cleared", () => {
@@ -846,14 +845,14 @@ describe(
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.hashAppend("/cell/B2");
 
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         // unhide ......................................................................................................

--- a/cypress/e2e/EmptyAndLoad.spec.js
+++ b/cypress/e2e/EmptyAndLoad.spec.js
@@ -36,7 +36,7 @@ describe(
 
             testing.hashEnter("/");
 
-            testing.hash().should('match', /.*\/Untitled/) // => true
+            testing.hash().should("match", /^#\/.*\/Untitled$/) // => true
 
             testing.spreadsheetEmptyCheck();
         });
@@ -47,8 +47,6 @@ describe(
                     const nonEmptySpreadsheetHash = win.location.hash;
 
                     testing.cellFormulaEnterAndSave(A1, "=1+2+3");
-
-                    testing.spreadsheetEmptyReady();
 
                     // reload previous spreadsheet and verify viewport reloaded
                     testing.hashEnter(nonEmptySpreadsheetHash);

--- a/cypress/e2e/LabelMapping.spec.js
+++ b/cypress/e2e/LabelMapping.spec.js
@@ -372,7 +372,7 @@ describe(
             testing.labelMappingDialogClosedCheck();
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
         });
 
         it("Save, navigate to label", () => {
@@ -386,7 +386,7 @@ describe(
                     testing.hashEnter(nonEmptySpreadsheetHash + "/label/Label456");
 
                     testing.hash()
-                        .should('match', /.*\/Untitled\/label\/Label456/);
+                        .should("match", /^#\/.*\/Untitled\/label\/Label456$/);
 
                     testing.labelMappingReferenceTextField()
                         .type("{selectall}" + reference.toString());
@@ -400,7 +400,7 @@ describe(
                     testing.hashEnter(nonEmptySpreadsheetHash + "/cell/Label456/formula");
 
                     testing.hash()
-                        .should('match', /.*\/Untitled\/cell\/Label456\/formula/);
+                        .should("match", /^#\/.*\/Untitled\/cell\/Label456\/formula$/);
 
                     testing.wait(50); // wait for formula text box to become enabled.
 

--- a/cypress/e2e/Row.spec.js
+++ b/cypress/e2e/Row.spec.js
@@ -36,7 +36,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/2/);
+                .should("match", /^#\/.*\/.*\/row\/2$/);
 
             testing.row("2")
                 .should("have.focus")
@@ -56,7 +56,7 @@ describe("Row",
                 .should("have.css", "background-color", SELECTED_COLOR);
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/3/);
+                .should("match", /^#\/.*\/.*\/row\/3$/);
         });
 
         // row range...................................................................................................
@@ -70,7 +70,7 @@ describe("Row",
                 .type("{shift+uparrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/4:5/);
+                .should("match", /^#\/.*\/.*\/row\/4:5\/bottom$/);
 
             testing.row("4")
                 .should("have.focus")
@@ -87,10 +87,8 @@ describe("Row",
             testing.row("5")
                 .type("{shift+downarrow}");
 
-            testing.historyWait();
-
             testing.hash()
-                .should('match', /.*\/.*\/row\/5:6/);
+                .should("match", /^#\/.*\/.*\/row\/5:6\/top$/);
 
             testing.row("6")
                 .should("have.focus")
@@ -107,15 +105,14 @@ describe("Row",
             testing.row("5")
                 .type("{shift+uparrow}");
 
-            testing.historyWait();
+            testing.hash()
+                .should("match", /^#\/.*\/.*\/row\/4:6\/bottom$/);
 
             testing.row("4")
                 .type("{shift+uparrow}");
 
-            testing.historyWait();
-
             testing.hash()
-                .should('match', /.*\/.*\/row\/3:6/);
+                .should("match", /^#\/.*\/.*\/row\/4:6\/bottom$/);
 
             testing.row("3")
                 .should("have.focus")
@@ -136,20 +133,20 @@ describe("Row",
             testing.row("5")
                 .type("{shift+downarrow}");
 
-            testing.historyWait();
+            testing.hash()
+                .should("match", /^#\/.*\/.*\/row\/6$/);
 
             testing.row("6")
                 .type("{shift+downarrow}");
 
-            testing.historyWait();
+            testing.hash()
+                .should("match", /^#\/.*\/.*\/row\/6:7\/top$/);
 
             testing.row("7")
                 .type("{shift+downarrow}");
 
-            testing.historyWait();
-
             testing.hash()
-                .should('match', /.*\/.*\/row\/6:8/);
+                .should("match", /^#\/.*\/.*\/row\/6:8\/top$/);
 
             testing.row("8")
                 .should("have.focus")
@@ -175,7 +172,7 @@ describe("Row",
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck("E4", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -194,7 +191,7 @@ describe("Row",
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck("E3", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -215,7 +212,7 @@ describe("Row",
             testing.historyWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/2/);
+                .should("match", /^#\/.*\/.*\/row\/2$/);
 
             testing.cellFormattedTextCheck("E6", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -232,7 +229,7 @@ describe("Row",
             testing.hashAppendWithoutCheck(":3/insert-after/2");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/2:3/);
+                .should("match", /^#\/.*\/.*\/row\/2:3$/);
 
             testing.cellFormattedTextCheck("E7", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -251,7 +248,7 @@ describe("Row",
             testing.hashAppendWithoutCheck("/insert-before/1");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/3/);
+                .should("match", /^#\/.*\/.*\/row\/3$/);
 
             testing.cellFormattedTextCheck("E6", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -268,7 +265,7 @@ describe("Row",
             testing.hashAppendWithoutCheck(":3/insert-before/2");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/4:5/);
+                .should("match", /^#\/.*\/.*\/row\/4:5$/);
 
             testing.cellFormattedTextCheck("E7", "Moved");
             testing.cellFormattedTextCheck(E5, "");
@@ -283,7 +280,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/.*\/cell\/A1/);
+                .should("match", /^#\/.*\/.*\/cell\/A1$/);
         });
 
         // row context menu...........................................................................................
@@ -301,7 +298,7 @@ describe("Row",
             testing.contextMenu(ROW_3.viewportId());
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/3\/menu/);
+                .should("match", /^#\/.*\/.*\/row\/3\/menu$/);
 
             testing.viewportContextMenu()
                 .should("be.visible")
@@ -319,43 +316,43 @@ describe("Row",
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_CLEAR_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/clear/);
+                .and("match", /#\/.*\/.*\/row\/2\/clear$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/delete/);
+                .and("match", /#\/.*\/.*\/row\/2\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/insert-after\/1/);
+                .and("match", /#\/.*\/.*\/row\/2\/insert-after\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/insert-after\/2/);
+                .and("match", /#\/.*\/.*\/row\/2\/insert-after\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/insert-before\/1/);
+                .and("match", /#\/.*\/.*\/row\/2\/insert-before\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/insert-before\/2/);
+                .and("match", /#\/.*\/.*\/row\/2\/insert-before\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:2\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1:2\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:3\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1:3\/freeze$/);
             
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2\/hidden\/true/);
+                .and("match", /#\/.*\/.*\/row\/2\/hidden\/true$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
@@ -370,43 +367,43 @@ describe("Row",
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_CLEAR_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/clear/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/clear$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/delete/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/delete$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/insert-after\/1/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/insert-after\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_AFTER_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/insert-after\/2/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/insert-after\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/insert-before\/1/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/insert-before\/1$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_INSERT_BEFORE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/insert-before\/2/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/insert-before\/2$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_1_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_2_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:2\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1:2\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_FREEZE_3_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/1:3\/freeze/);
+                .and("match", /#\/.*\/.*\/row\/1:3\/freeze$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_HIDE_ID)
                 .should("have.attr", "href")
-                .and('match', /#*\/*\/row\/2:3\/hidden\/true/);
+                .and("match", /#\/.*\/.*\/row\/2:3\/hidden\/true$/);
 
             testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_UNFREEZE_ID);
         });
@@ -446,7 +443,7 @@ describe("Row",
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/2:3\/top/);
+                .should("match", /^#\/.*\/.*\/row\/2:3\/top$/);
 
             testing.contextMenu(ROW_2.viewportId());
 
@@ -500,7 +497,7 @@ describe("Row",
                 .type("{shift+downarrow}");
 
             testing.hash()
-                .should('match', /.*\/.*\/row\/2:3\/top/);
+                .should("match", /^#\/.*\/.*\/row\/2:3\/top$/);
 
             testing.contextMenu(ROW_2.viewportId());
 
@@ -610,7 +607,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/3/);
+                .should("match", /^#\/.*\/Untitled\/row\/3$/);
 
             testing.contextMenu(ROW_3.viewportId());
 
@@ -626,7 +623,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/5/);
+                .should("match", /^#\/.*\/Untitled\/row\/5$/);
 
             testing.cellFormattedTextCheck("C5", "Moved");
             testing.cellFormattedTextCheck(C3, "");
@@ -639,7 +636,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/3/);
+                .should("match", /^#\/.*\/Untitled\/row\/3$/);
 
             testing.contextMenu(ROW_3.viewportId());
 
@@ -655,7 +652,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/4/);
+                .should("match", /^#\/.*\/Untitled\/row\/4$/);
 
             testing.cellFormattedTextCheck("C4", "Moved");
             testing.cellFormattedTextCheck(C3, "");
@@ -669,7 +666,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/2/);
+                .should("match", /^#\/.*\/Untitled\/row\/2$/);
 
             testing.contextMenu(ROW_2.viewportId());
 
@@ -685,7 +682,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/2/);
+                .should("match", /^#\/.*\/Untitled\/row\/2$/);
 
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("C4", "Moved");
@@ -700,7 +697,7 @@ describe("Row",
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/2/);
+                .should("match", /^#\/.*\/Untitled\/row\/2$/);
 
             testing.contextMenu(ROW_2.viewportId());
 
@@ -716,7 +713,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/2/);
+                .should("match", /^#\/.*\/Untitled\/row\/2$/);
 
             testing.cellFormattedTextCheck("A1", "Never");
             testing.cellFormattedTextCheck("C5", "Moved");
@@ -742,7 +739,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck(A1, "Before");
             testing.get(B2.viewportId())
@@ -775,7 +772,7 @@ describe("Row",
                 .should("not.be.visible");
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.cellFormattedTextCheck(A1, "Before");
             testing.get(B2.viewportId())
@@ -802,14 +799,14 @@ describe("Row",
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.hashAppend("/row/2");
 
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         it("Attempt to history hash select cell in hidden row cleared", () => {
@@ -829,14 +826,14 @@ describe("Row",
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
 
             testing.hashAppend("/cell/B2");
 
             testing.columnWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         // unhide ......................................................................................................

--- a/cypress/e2e/Select.spec.js
+++ b/cypress/e2e/Select.spec.js
@@ -82,7 +82,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
 
             testing.selectDialog()
                 .should("not.exist");
@@ -95,7 +95,7 @@ describe(
                 .type("{esc}");
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
 
             testing.selectDialog()
                 .should("not.exist");
@@ -136,7 +136,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/B2/);
+                .should("match", /^#\/.*\/Untitled\/cell\/B2$/);
         });
 
         it("Enter cell range and ENTER and click SELECT CELL RANGE", () => {
@@ -164,7 +164,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/A1:B2/);
+                .should("match", /^#\/.*\/Untitled\/cell\/A1:B2$/);
         });
 
         it("Enter unknown label and ENTER and click CREATE", () => {
@@ -192,7 +192,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/label\/Label123/);
+                .should("match", /^#\/.*\/Untitled\/label\/Label123$/);
         });
 
         it("Enter known label and ENTER and click LABEL EDIT", () => {
@@ -211,7 +211,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
 
             testing.selectHistoryHash();
 
@@ -237,7 +237,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/label\/Label123/);
+                .should("match", /^#\/.*\/Untitled\/label\/Label123$/);
         });
 
         it("Click CELL then select create LABEL and ENTER, verify cell not lost from hash", () => {
@@ -245,7 +245,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/A1/);
+                .should("match", /^#\/.*\/Untitled\/cell\/A1$/);
 
             testing.selectHistoryHash(); // TODO not sure WHY but select dialog doesnt appear in test.
 
@@ -271,7 +271,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/A1\/label\/Label123/);
+                .should("match", /^#\/.*\/Untitled\/cell\/A1\/label\/Label123$/);
         });
 
         it("Enter cell, select from dropdown ENTER and click GOTO CELL", () => {
@@ -305,7 +305,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/B2/);
+                .should("match", /^#\/.*\/Untitled\/cell\/B2$/);
         });
 
         it("Enter column, select from dropdown ENTER and click GOTO COLUMN", () => {
@@ -341,7 +341,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/C/);
+                .should("match", /^#\/.*\/Untitled\/column\/C$/);
         });
 
         it("Enter column range, select from dropdown ENTER and click SELECT COLUMN RANGE", () => {
@@ -375,7 +375,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/column\/D:E/);
+                .should("match", /^#\/.*\/Untitled\/column\/D:E$/);
         });
 
         it("Enter known label ENTER and click LABEL EDIT", () => {
@@ -414,7 +414,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/label\/Label123/);
+                .should("match", /^#\/.*\/Untitled\/label\/Label123$/);
         });
 
         it("Enter existing label, select from dropdown ENTER and click GOTO LABEL", () => {
@@ -462,7 +462,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/Label123/);
+                .should("match", /^#\/.*\/Untitled\/cell\/Label123$/);
         });
 
         it("Enter row, select from dropdown ENTER and click GOTO ROW", () => {
@@ -496,7 +496,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/3/);
+                .should("match", /^#\/.*\/Untitled\/row\/3$/);
         });
 
         it("Enter row range, select from dropdown ENTER and click SELECT ROW RANGE", () => {
@@ -530,7 +530,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/row\/4:6/);
+                .should("match", /^#\/.*\/Untitled\/row\/4:6$/);
         });
 
         it("Cell click then verify Select link", () => {
@@ -553,7 +553,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/B1\/select/);
+                .should("match", /^#\/.*\/Untitled\/cell\/B1\/select$/);
 
             testing.selectAutocompleteTextField()
                 .should("have.value", "")
@@ -563,7 +563,7 @@ describe(
                 .click();
 
             testing.hash()
-                .should('match', /.*\/Untitled\/cell\/B2/);
+                .should("match", /^#\/.*\/Untitled\/cell\/B2$/);
         });
     }
 );

--- a/cypress/e2e/Settings.spec.js
+++ b/cypress/e2e/Settings.spec.js
@@ -47,7 +47,7 @@ describe(
                 .should('be.visible');
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/) // => true
+                .should("match", /^#\/.*\/.*\/settings$/) // => true
 
             settingsToggle();
 
@@ -55,7 +55,7 @@ describe(
                 .should('be.not.visible');
 
             testing.hash()
-                .should('not.match', /.*\/.*\/settings/);
+                .should('not.match', /^#\/.*\/.*\/settings$/);
         });
 
         it("Hash show settings", () => {
@@ -82,7 +82,7 @@ describe(
             settingsToggle();
 
             cy.hash()
-                .should("match", /.*\/Untitled\/settings/);
+                .should("match", /^#\/.*\/Untitled\/settings$/);
 
             settings()
                 .should("contains.text", "Metadata")
@@ -96,7 +96,7 @@ describe(
             settingsToggle();
 
             cy.hash()
-                .should("match", /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
         });
 
         it("Metadata check creator-date-time/modified-date-time", () => {
@@ -992,7 +992,7 @@ describe(
                 .should('be.visible');
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/);
+                .should("match", /^#\/.*\/.*\/settings$/);
 
             testing.settings()
                 .should("have.focus")
@@ -1001,7 +1001,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings\/metadata/);
+                .should("match", /^#\/.*\/.*\/settings\/metadata$/);
 
             testing.settingsAccordion("metadata")
                 .should("have.focus")
@@ -1010,7 +1010,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings\/text/);
+                .should("match", /^#\/.*\/.*\/settings\/text$/);
 
             testing.settingsAccordion("text")
                 .should("have.focus")
@@ -1019,7 +1019,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings\/number/);
+                .should("match", /^#\/.*\/.*\/settings\/number$/);
 
             testing.settingsAccordion("number")
                 .should("have.focus")
@@ -1028,7 +1028,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings\/date-time/);
+                .should("match", /^#\/.*\/.*\/settings\/date-time$/);
 
             testing.settingsAccordion("date-time")
                 .should("have.focus")
@@ -1037,7 +1037,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings\/style/);
+                .should("match", /^#\/.*\/.*\/settings\/style$/);
 
 
             testing.settingsAccordion("style")
@@ -1047,14 +1047,14 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', /.*\/.*/);
+                .should("match", /^#\/.*\/.*$/);
         });
 
         it("Tabbing metadata", () => {
             settingsToggle();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/) // => true
+                .should("match", /^#\/.*\/.*\/settings$/) // => true
 
             tabAccordion("metadata");
         });
@@ -1063,7 +1063,7 @@ describe(
             settingsToggle();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/) // => true
+                .should("match", /^#\/.*\/.*\/settings$/) // => true
 
             //tabAccordion("metadata", false);
 
@@ -1084,7 +1084,7 @@ describe(
             settingsToggle();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/);
+                .should("match", /^#\/.*\/.*\/settings$/);
 
             tabAccordion("number");
 
@@ -1107,7 +1107,7 @@ describe(
             settingsToggle();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/);
+                .should("match", /^#\/.*\/.*\/settings$/);
 
             tabAccordion("date-time");
 
@@ -1126,7 +1126,7 @@ describe(
             settingsToggle();
 
             testing.hash()
-                .should('match', /.*\/.*\/settings/);
+                .should("match", /^#\/.*\/.*\/settings$/);
 
             tabAccordion("style");
 
@@ -1174,7 +1174,7 @@ describe(
             }
 
             testing.hash()
-                .should('match', new RegExp(".*\/.*\/settings\/" + accordion));
+                .should("match", new RegExp(".*\/.*\/settings\/" + accordion));
 
             // tab
             testing.settingsAccordion(accordion)
@@ -1198,7 +1198,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', new RegExp(".*\/.*\/settings\/" + property));
+                .should("match", new RegExp(".*\/.*\/settings\/" + property));
 
             testing.focused()
                 .scrollIntoView()
@@ -1221,7 +1221,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', new RegExp(".*\/.*\/settings\/" + property));
+                .should("match", new RegExp(".*\/.*\/settings\/" + property));
 
             const id = SpreadsheetSettingsWidget.propertyId(property);
 
@@ -1241,7 +1241,7 @@ describe(
             testing.settingsWait();
 
             testing.hash()
-                .should('match', new RegExp(".*\/.*\/settings\/" + property));
+                .should("match", new RegExp(".*\/.*\/settings\/" + property));
 
             testing.focused()
                 .scrollIntoView()
@@ -1266,12 +1266,12 @@ describe(
                 .blur();
 
             cy.hash()
-                .should("matches", /.*\/Untitled/);
+                .should("matches", /^#\/.*\/Untitled$/);
 
             settingsToggle();
 
             cy.hash()
-                .should("matches", /.*\/Untitled\/settings/);
+                .should("matches", /^#\/.*\/Untitled\/settings$/);
         });
 
         it("Edit cell then toggle settings", () => {
@@ -1280,7 +1280,7 @@ describe(
             settingsToggle();
 
             cy.hash()
-                .should("matches", /.*\/Untitled\/cell\/A1\/settings/);
+                .should("matches", /^#\/.*\/Untitled\/cell\/A1\/settings$/);
         });
 
         /**

--- a/cypress/e2e/SpreadsheetName.spec.js
+++ b/cypress/e2e/SpreadsheetName.spec.js
@@ -48,7 +48,7 @@ context(
                 .should("eq", "Untitled");
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
         });
 
         it("Edit & blur changes lost", () => {
@@ -68,7 +68,7 @@ context(
                 .should("eq", "Untitled");
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
         });
 
         it("Edit, blur, edit again changes lost", () => {
@@ -88,7 +88,7 @@ context(
                 .should("eq", "Untitled");
 
             testing.hash()
-                .should('match', /.*\/Untitled/);
+                .should("match", /^#\/.*\/Untitled$/);
 
             // edit again
             testing.spreadsheetNameButtonClick();
@@ -118,7 +118,7 @@ context(
                 .should("eq", updatedSpreadsheetName.toString());
 
             testing.hash()
-                .should('match', /.*\/SpreadsheetName234/);
+                .should("match", /^#\/.*\/SpreadsheetName234$/);
         });
     }
 );

--- a/cypress/e2e/SpreadsheetTesting.js
+++ b/cypress/e2e/SpreadsheetTesting.js
@@ -40,7 +40,7 @@ export default class SpreadsheetTesting {
 
     spreadsheetEmptyReady() {
         this.hash()
-            .should('match', /.*\/Untitled/); // wait for /$id/$name
+            .should("match", /^#\/.*\/Untitled$/); // wait for /$id/$name
 
         this.historyWait();
     }
@@ -120,7 +120,7 @@ export default class SpreadsheetTesting {
                     this.hashEnter(h.substring(0, slash2));
 
                     this.hash()
-                        .should('match', /.*\/.*/);
+                        .should("match", /^#\/.*\/.*$/);
                 }
             });
     }
@@ -163,12 +163,12 @@ export default class SpreadsheetTesting {
         this.spreadsheetNameWait();
 
         this.hash()
-            .should('match', /.*\/.*\/name/);
+            .should("match", /^#\/.*\/.*\/name$/);
     }
 
     spreadsheetNameTextField() {
         this.hash()
-            .should('match', /.*\/.*\/name/);
+            .should("match", /^#\/.*\/.*\/name$/);
 
         return this.getById(SpreadsheetNameWidget.TEXT_FIELD_ID);
     }
@@ -186,7 +186,7 @@ export default class SpreadsheetTesting {
             .click();
 
         this.hash()
-            .should('match', /\/.*\/.*\/cell\/.*\/formula(\/.*)*/);
+            .should("match", /^#\/.*\/.*\/cell\/.*\/formula(\/.*)*$/);
 
         this.formulaTextLoadWait();
     }
@@ -362,7 +362,7 @@ export default class SpreadsheetTesting {
             .click(SpreadsheetTesting.FORCE_TRUE);
 
         this.hash()
-            .should('match', new RegExp("\/.*\/.*\/cell\/" + cellReference + "(\/.*)*"));
+            .should("match", new RegExp("^#\/.*\/.*\/cell\/" + cellReference + "(\/.*)*"));
 
         this.cell(cellReference)
             .should("have.focus");
@@ -433,7 +433,7 @@ export default class SpreadsheetTesting {
      */
     spreadsheetEmptyCheck() {
         this.hash()
-            .should('match', /.*\/Untitled/) // => true
+            .should("match", /^#\/.*\/Untitled$/) // => true
 
         // Verify spreadsheet name is "Untitled"
         this.spreadsheetNameButton()
@@ -445,8 +445,7 @@ export default class SpreadsheetTesting {
 
         // Verify formula is read only and empty
         this.formulaText()
-            .should("be.disabled")
-            .should("have.text", "");
+            .should("be.hidden");
 
         this.cy.get(SpreadsheetTesting.COLUMN + SpreadsheetTesting.SELECTED)
             .should("have.length", 0);


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1882
- Add carot and dollar to all regexp in e2e tests.

- Made regexp exact (added missing leading carot and trailing dollar-sign to many patterns.)
- EmptyAndLoad: Updated test to expect hidden not disabled formula component.
- Row tests are flakey probably due to duplicate browser requests.