### PR TITLE
SpreadsheetName edit save history-hash & document.title fix

### DIFF
--- a/cypress/e2e/SpreadsheetName.spec.js
+++ b/cypress/e2e/SpreadsheetName.spec.js
@@ -118,7 +118,7 @@ context(
                 .should("eq", updatedSpreadsheetName.toString());
 
             testing.hash()
-                .should("match", /^#\/.*\/SpreadsheetName234$/);
+                .should("match", /^#\/.*\/SpreadsheetName234\/name$/);
         });
     }
 );

--- a/src/spreadsheet/meta/SpreadsheetNameWidget.js
+++ b/src/spreadsheet/meta/SpreadsheetNameWidget.js
@@ -172,8 +172,11 @@ export default class SpreadsheetNameWidget extends SpreadsheetHistoryAwareStateW
         const tokens = this.props.history.tokens();
         const edit = tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME_EDIT];
         if(edit instanceof SpreadsheetNameSaveHistoryHashToken) {
+            tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME] = spreadsheetName;
             tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME_EDIT] = SpreadsheetNameEditHistoryHashToken.INSTANCE;
             this.historyParseMergeAndPush(tokens);
+
+            document.title = spreadsheetName;
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1976
- history hash spreadsheet name part & window title not updated after a spreadsheet name edit save