### PR TITLE
viewport columns & rows link fix

### DIFF
--- a/src/spreadsheet/reference/columnrow/SpreadsheetColumnOrRowReference.js
+++ b/src/spreadsheet/reference/columnrow/SpreadsheetColumnOrRowReference.js
@@ -1,13 +1,10 @@
+import Link from "@mui/material/Link";
 import Preconditions from "../../../Preconditions.js";
 import React from "react";
 import SpreadsheetReferenceKind from "../SpreadsheetReferenceKind.js";
 import SpreadsheetSelection from "../SpreadsheetSelection.js";
 import SpreadsheetViewportSelectionAnchor from "../viewport/SpreadsheetViewportSelectionAnchor.js";
 import TableCell from "@mui/material/TableCell";
-import Link from "@mui/material/Link";
-import SpreadsheetHistoryHashTokens from "../../history/SpreadsheetHistoryHashTokens.js";
-import SpreadsheetColumnOrRowSelectHistoryHashToken from "./SpreadsheetColumnOrRowSelectHistoryHashToken.js";
-import SpreadsheetHistoryHash from "../../history/SpreadsheetHistoryHash.js";
 
 export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelection {
 
@@ -87,20 +84,24 @@ export default class SpreadsheetColumnOrRowReference extends SpreadsheetSelectio
 
     // selection........................................................................................................
 
+    viewportLinkId() {
+        return this.viewportId() + "-Link";
+    }
+
     /**
      * Renders a TABLE CELL that may be highlighted.
      */
-    renderViewport(style, tokens) {
+    // $link must be stringified and passed as a string because passing tokens for eventual SpreadsheetHistoryHash.stringify
+    // will cause weird cycling reference failures in tests but not in a browser
+    renderViewport(style, link) {
         const id = this.viewportId();
 
-        tokens[SpreadsheetHistoryHashTokens.SELECTION] = new SpreadsheetColumnOrRowSelectHistoryHashToken(this);
-        const link = "#" + SpreadsheetHistoryHash.stringify(tokens);
-
         return <TableCell key={id}
+                          id={id}
                           style={style}
                           tabIndex={0}
                           data-selection={this}
-        ><Link id={id}
+        ><Link id={this.viewportLinkId()}
                href={link}
                style={{
                    display: "inline-block",

--- a/src/spreadsheet/reference/columnrow/SpreadsheetColumnReference.test.js
+++ b/src/spreadsheet/reference/columnrow/SpreadsheetColumnReference.test.js
@@ -1,10 +1,13 @@
+import Link from "@mui/material/Link";
+import React from "react";
+import SpreadsheetCellRange from "../cell/SpreadsheetCellRange.js";
 import SpreadsheetCellReference from "../cell/SpreadsheetCellReference.js";
 import SpreadsheetColumn from "./SpreadsheetColumn.js";
 import SpreadsheetColumnReference from "./SpreadsheetColumnReference.js";
 import SpreadsheetReferenceKind from "../SpreadsheetReferenceKind.js";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import systemObjectTesting from "../../../SystemObjectTesting.js";
-import SpreadsheetCellRange from "../cell/SpreadsheetCellRange.js";
+import TableCell from "@mui/material/TableCell";
 
 systemObjectTesting(
     new SpreadsheetColumnReference(0, SpreadsheetReferenceKind.ABSOLUTE),
@@ -425,6 +428,34 @@ function toRelativeAndCheck(selection, expected) {
 
 toRelativeAndCheck("A", "A");
 toRelativeAndCheck("$B", "B");
+
+// renderViewport.......................................................................................................
+
+test("renderViewport", () => {
+    const style = {
+        "color": "#ABCDEF",
+    };
+
+    const reference = SpreadsheetColumnReference.parse("AB");
+
+    expect(
+        reference.renderViewport(style, "#/123/SpreadsheetName/column/AB")
+    ).toEqual(<TableCell key={"viewport-column-AB"}
+                         id={"viewport-column-AB"}
+                         style={style}
+                         tabIndex={0}
+                         data-selection={reference}
+        ><Link id="viewport-column-AB-Link"
+               href="#/123/SpreadsheetName/column/AB"
+               style={{
+                   display: "inline-block",
+                   paddingLeft: "1ex",
+                   paddingRight: "1ex",
+                   paddingTop: "2px",
+                   paddingBottom: "2px",
+               }}>AB</Link></TableCell>
+    );
+});
 
 // equals................................................................................................................
 

--- a/src/spreadsheet/reference/columnrow/SpreadsheetRowReference.test.js
+++ b/src/spreadsheet/reference/columnrow/SpreadsheetRowReference.test.js
@@ -5,6 +5,9 @@ import SpreadsheetRow from "./SpreadsheetRow.js";
 import SpreadsheetRowReference from "./SpreadsheetRowReference.js";
 import systemObjectTesting from "../../../SystemObjectTesting.js";
 import SpreadsheetCellRange from "../cell/SpreadsheetCellRange.js";
+import TableCell from "@mui/material/TableCell";
+import Link from "@mui/material/Link";
+import React from "react";
 
 systemObjectTesting(
     new SpreadsheetRowReference(0, SpreadsheetReferenceKind.ABSOLUTE),
@@ -359,6 +362,34 @@ function toRelativeAndCheck(selection, expected) {
 
 toRelativeAndCheck("1", "1");
 toRelativeAndCheck("$2", "2");
+
+// renderViewport.......................................................................................................
+
+test("renderViewport", () => {
+    const style = {
+        "color": "#ABCDEF",
+    };
+
+    const reference = SpreadsheetRowReference.parse("123");
+
+    expect(
+        reference.renderViewport(style, "#/123/SpreadsheetName/row/123")
+    ).toEqual(<TableCell key={"viewport-row-123"}
+                         id={"viewport-row-123"}
+                         style={style}
+                         tabIndex={0}
+                         data-selection={reference}
+        ><Link id="viewport-row-123-Link"
+               href="#/123/SpreadsheetName/row/123"
+               style={{
+                   display: "inline-block",
+                   paddingLeft: "1ex",
+                   paddingRight: "1ex",
+                   paddingTop: "2px",
+                   paddingBottom: "2px",
+               }}>123</Link></TableCell>
+    );
+});
 
 // compareTo..............................................................................................................
 

--- a/src/spreadsheet/reference/viewport/SpreadsheetViewportWidget.js
+++ b/src/spreadsheet/reference/viewport/SpreadsheetViewportWidget.js
@@ -445,6 +445,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
 
         return {
             spreadsheetId: historyHashTokens[SpreadsheetHistoryHash.SPREADSHEET_ID],
+            spreadsheetName: historyHashTokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME],
             cellReferenceToCells: ImmutableMap.EMPTY,
             cellReferenceToLabels: ImmutableMap.EMPTY,
             columnReferenceToColumns: ImmutableMap.EMPTY,
@@ -463,6 +464,8 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
         console.log("Viewport stateFromHistoryTokens " + JSON.stringify(tokens));
 
         return {
+            spreadsheetId: tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_ID],
+            spreadsheetName: tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME],
             selection: tokens[SpreadsheetHistoryHashTokens.SELECTION],
             contextMenu: null, // close context menu
         };
@@ -990,6 +993,8 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
             columnWidths,
             rowHeights,
             contextMenu,
+            spreadsheetId,
+            spreadsheetName,
         } = this.state;
 
         const width = dimensions.width;
@@ -1008,8 +1013,8 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
         const menuItems = contextMenu && contextMenu.items();
 
         const tokens = SpreadsheetHistoryHashTokens.emptyTokens();
-        tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_ID] = this.state[SpreadsheetHistoryHashTokens.SPREADSHEET_ID];
-        tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME] = this.state[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME];
+        tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_ID] = spreadsheetId;
+        tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME] = spreadsheetName;
 
         return [
             <TableContainer id={SpreadsheetViewportWidget.VIEWPORT_ID}
@@ -1193,13 +1198,17 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
         ];
 
         columns.forEach(c => {
+            tokens[SpreadsheetHistoryHashTokens.SELECTION] = selectHistoryHashToken(
+                new SpreadsheetViewportSelection(c)
+            );
+
             headers.push(
                 c.renderViewport(
                     COLUMN_HEADER(
                         columnWidth(c),
                         selection && selection.testColumn(c)
                     ),
-                    tokens
+                    "#" + SpreadsheetHistoryHash.stringify(tokens)
                 )
             );
         });
@@ -1221,6 +1230,10 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
                 const tableRowCells = [];
                 const height = rowHeightFn(r);
 
+                tokens[SpreadsheetHistoryHashTokens.SELECTION] = selectHistoryHashToken(
+                    new SpreadsheetViewportSelection(r)
+                );
+
                 // render ROW gutter widget with row number.
                 tableRowCells.push(
                     r.renderViewport(
@@ -1228,7 +1241,7 @@ export default class SpreadsheetViewportWidget extends SpreadsheetCellWidget {
                             height,
                             selection && selection.testRow(r)
                         ),
-                        tokens
+                        "#" + SpreadsheetHistoryHash.stringify(tokens)
                     )
                 );
 


### PR DESCRIPTION
- Removing SpreadsheetHistoryHash from SpreadsheetColumnOrRowReference.renderViewport also fixed all weird extend class is missing failures in tests.