### PR TITLE
Changed formula/save/$formula-text added "save" token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Following the selection of a cell, the following commands are possible
 
 - /delete Deletes the cell or cell-range
 - /formula Loads the formula text box with the current value for this cell
-- /formula/$formula Saves the given $formula for the cell.
+- /formula/save/$formula-text Saves the given $formula-text for the cell.
 - /menu Displays a context menu
 
 > /#123/Untitled/cell/D4/delete
@@ -115,7 +115,7 @@ Following the selection of a cell, the following commands are possible
 > 
 > /#123/Untitled/cell/G7/formula
 > 
-> /#123/Untitled/cell/H8/formula/=1+2
+> /#123/Untitled/cell/H8/formula/save/=1+2
 
 > /#123/Untitled/cell/I9/menu
 >

--- a/cypress/e2e/Cell.spec.js
+++ b/cypress/e2e/Cell.spec.js
@@ -40,7 +40,7 @@ describe(
 
             testing.formulaTextClick();
 
-            testing.hashAppend("/=2*3")
+            testing.hashAppend("/save/=2*3")
 
             testing.cellFormattedTextCheck(B2, "6.");
         });

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -188,11 +188,24 @@ export default class SpreadsheetHistoryHash extends SpreadsheetHistoryHashTokens
                                                 if(null == token){
                                                     viewportSelectionToken = new SpreadsheetCellFormulaEditHistoryHashToken(viewportSelection);
                                                 }else {
-                                                    viewportSelectionToken = new SpreadsheetCellFormulaSaveHistoryHashToken(
-                                                        viewportSelection,
-                                                        decodeURIComponent(token)
-                                                    );
-                                                    token = tokens.shift();
+                                                    switch(token) {
+                                                        case SpreadsheetHistoryHashTokens.SAVE:
+                                                            token = tokens.shift();
+                                                            if(null == token){
+                                                                errors("Missing formula text");
+                                                                break Loop;
+                                                            }
+                                                            viewportSelectionToken = new SpreadsheetCellFormulaSaveHistoryHashToken(
+                                                                viewportSelection,
+                                                                decodeURIComponent(token)
+                                                            );
+                                                            token = tokens.shift();
+                                                            break;
+                                                        default:
+                                                            // not a formula save
+                                                            viewportSelectionToken = new SpreadsheetCellFormulaEditHistoryHashToken(viewportSelection);
+                                                            break;
+                                                    }
                                                 }
                                             }
                                             break;

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -648,19 +648,16 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/save",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
-        "viewport-selection": new SpreadsheetCellFormulaSaveHistoryHashToken(
-            new SpreadsheetViewportSelection(CELL),
-            ""
-        ),
-    }
+    },
+    "Missing formula text"
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/ABC%20123",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/save/ABC%20123",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
@@ -672,7 +669,7 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/=12%2F34",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/save/=12%2F34",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
@@ -680,6 +677,16 @@ testParseAndStringify(
             new SpreadsheetViewportSelection(CELL),
             "=12/34"
         ),
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/formula/select",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "viewport-selection": CELL_FORMULA_LOAD_EDIT,
+        "select": true,
     }
 );
 
@@ -699,6 +706,16 @@ testParseAndStringify(
         "spreadsheet-name": SPREADSHEET_NAME,
         "viewport-selection": CELL_SELECT,
         "metadata": METADATA_NOTHING,
+    }
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/select",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME,
+        "viewport-selection": CELL_SELECT,
+        "select": true,
     }
 );
 
@@ -787,7 +804,7 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/Label123/formula/ABC%20123",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/Label123/formula/save/ABC%20123",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,

--- a/src/spreadsheet/reference/cell/formula/SpreadsheetCellFormulaEditHistoryHashToken.js
+++ b/src/spreadsheet/reference/cell/formula/SpreadsheetCellFormulaEditHistoryHashToken.js
@@ -6,9 +6,8 @@ import SpreadsheetHistoryHashTokens from "../../../history/SpreadsheetHistoryHas
  */
 export default class SpreadsheetCellFormulaEditHistoryHashToken extends SpreadsheetCellFormulaHistoryHashToken {
 
-    constructor(spreadsheetViewport, formulaText) {
+    constructor(spreadsheetViewport) {
         super(spreadsheetViewport);
-        this.formulaTextValue = formulaText;
     }
 
     formulaText() {
@@ -20,18 +19,8 @@ export default class SpreadsheetCellFormulaEditHistoryHashToken extends Spreadsh
     }
 
     historyHashPath() {
-        const formulaText = this.formulaText();
-
         return super.historyHashPath() +
             "/" +
-            SpreadsheetHistoryHashTokens.CELL_FORMULA +
-            (formulaText != null ?
-                "/" + encodeURIComponent(formulaText) :
-                "");
-    }
-
-    equals(other) {
-        return super.equals(other) &&
-            this.formulaText() === other.formulaText();
+            SpreadsheetHistoryHashTokens.CELL_FORMULA;
     }
 }

--- a/src/spreadsheet/reference/cell/formula/SpreadsheetCellFormulaSaveHistoryHashToken.js
+++ b/src/spreadsheet/reference/cell/formula/SpreadsheetCellFormulaSaveHistoryHashToken.js
@@ -17,10 +17,13 @@ export default class SpreadsheetCellFormulaSaveHistoryHashToken extends Spreadsh
         return this.formulaTextValue;
     }
 
+    // cell/A1/formula/save/=1+2
     historyHashPath() {
         return super.historyHashPath() +
             "/" +
             SpreadsheetHistoryHashTokens.CELL_FORMULA +
+            "/" +
+            SpreadsheetHistoryHashTokens.SAVE +
             "/" +
             encodeURIComponent(this.formulaText());
     }


### PR DESCRIPTION
- Without the save token hashes like /cell/A1/formula/select were interpreted as saving a formula with "select" and not formula edit then select.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/2034
- clicking select link when editing a formula causes a formula save with text = "select".