### PR TITLE
history-hash: cell/style edit & save tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Following the selection of a cell, the following commands are possible
 - /formula Loads the formula text box with the current value for this cell
 - /formula/save/$formula-text Saves the given $formula-text for the cell.
 - /menu Displays a context menu
+- /style/$property-name selects the style property widget for editing for the selected cells.
+- /style/$property-name/save/$property-value saves the style property with the value for the selected cells.
 
 > /#123/Untitled/cell/D4/delete
 > 
@@ -121,6 +123,13 @@ Following the selection of a cell, the following commands are possible
 >
 > /#123/Untitled/cell/J10:K11/menu
 
+> /#123/Untitled/cell/M12/style/font-style/edit
+>
+> /#123/Untitled/cell/N13:O14/style/font-style/edit
+
+> /#123/Untitled/cell/P15/style/font-style/save/ITALICS
+>
+> /#123/Untitled/cell/Q16:R17/style/font-style/save/ITALICS
 
 #### /spreadsheet-id/spreadsheet-name/column/column-or-column-range
 

--- a/cypress/e2e/Cell.spec.js
+++ b/cypress/e2e/Cell.spec.js
@@ -185,7 +185,7 @@ describe(
         });
 
         it("Cell history save style", () => {
-            testing.hashAppend("/cell/A1/style/color/#123456");
+            testing.hashAppend("/cell/A1/style/color/save/#123456");
 
             //testing.cellFormattedTextCheck(A1, "");
             testing.cellStyleCheck(A1, "color", "rgb(18, 52, 86)");

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -223,28 +223,45 @@ export default class SpreadsheetHistoryHash extends SpreadsheetHistoryHashTokens
                                             token = tokens.shift();
                                             break;
                                         case SpreadsheetHistoryHashTokens.STYLE:
-                                            // cell/A1/style/font-style/italics
+                                            // cell/A1/style/font-style/select/italics etc.
                                             token = tokens.shift(); // style property name
                                             if(null != token){
                                                 const stylePropertyName = token;
                                                 if(TextStyle.isProperty(stylePropertyName)){
-                                                    if(tokens.length){
-                                                        token = tokens.shift(); // style property value
-                                                        viewportSelectionToken = new SpreadsheetCellStyleSaveHistoryHashToken(
-                                                            viewportSelection,
-                                                            stylePropertyName,
-                                                            TextStyle.parseHistoryHashToken(
-                                                                stylePropertyName,
-                                                                token
-                                                            )
-                                                        );
+                                                    const styleAction = tokens.shift(); // style property command eg edit | save
+                                                    if(styleAction){
+                                                        switch(styleAction) {
+                                                            case SpreadsheetHistoryHashTokens.EDIT:
+                                                                viewportSelectionToken = new SpreadsheetCellStyleEditHistoryHashToken(
+                                                                    viewportSelection,
+                                                                    stylePropertyName
+                                                                );
+                                                                token = tokens.shift();
+                                                                break;
+                                                            case SpreadsheetHistoryHashTokens.SAVE:
+                                                                token = tokens.shift();
+                                                                if(token) {
+                                                                    viewportSelectionToken = new SpreadsheetCellStyleSaveHistoryHashToken(
+                                                                        viewportSelection,
+                                                                        stylePropertyName,
+                                                                        TextStyle.parseHistoryHashToken(
+                                                                            stylePropertyName,
+                                                                            encodeURIComponent(token)
+                                                                        )
+                                                                    );
+                                                                    token = tokens.shift();
+                                                                } else {
+                                                                    errors("Missing save value");
+                                                                    break Loop;
+                                                                }
+                                                                break;
+                                                            default:
+                                                                errors("Invalid style: " + styleAction);
+                                                                break Loop;
+                                                        }
                                                     }else {
-                                                        viewportSelectionToken = new SpreadsheetCellStyleEditHistoryHashToken(
-                                                            viewportSelection,
-                                                            stylePropertyName
-                                                        );
+                                                        tokens.unshift(token); // error
                                                     }
-                                                    token = tokens.shift();
                                                 }else {
                                                     tokens.unshift(token);
                                                 }

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -2160,7 +2160,16 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/style/font-style",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/style/font-size",
+    {
+        "spreadsheet-id": "spreadsheet-id-123",
+        "spreadsheet-name": SPREADSHEET_NAME
+    },
+    "Invalid token: \"font-size\"",
+);
+
+testParseAndStringify(
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/style/font-style/edit",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
@@ -2174,7 +2183,7 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/style/font-style/ITALIC",
+    "/spreadsheet-id-123/spreadsheet-name-456/cell/A1/style/font-style/save/ITALIC",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,

--- a/src/spreadsheet/history/SpreadsheetHistoryHashTokens.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHashTokens.js
@@ -40,6 +40,7 @@ export default class SpreadsheetHistoryHashTokens {
     static STYLE = "style";
     static UNFREEZE = "unfreeze";
 
+    static EDIT = "edit";
     static SAVE = "save";
 
     static LABEL = "label";

--- a/src/spreadsheet/reference/cell/style/SpreadsheetCellStyleEditHistoryHashToken.js
+++ b/src/spreadsheet/reference/cell/style/SpreadsheetCellStyleEditHistoryHashToken.js
@@ -2,6 +2,7 @@ import CharSequences from "../../../../CharSequences.js";
 import Equality from "../../../../Equality.js";
 import Preconditions from "../../../../Preconditions.js";
 import SpreadsheetCellStyleHistoryHashToken from "./SpreadsheetCellStyleHistoryHashToken.js";
+import SpreadsheetHistoryHashTokens from "../../../history/SpreadsheetHistoryHashTokens.js";
 import TextStyle from "../../../../text/TextStyle.js";
 
 /**
@@ -26,10 +27,13 @@ export default class SpreadsheetCellStyleEditHistoryHashToken extends Spreadshee
         return this.propertyNameValue;
     }
 
+    // /cell/A1/style/font-style/edit
     historyHashPath() {
         return super.historyHashPath() +
             "/" +
-            this.propertyName();
+            this.propertyName() +
+            "/" +
+            SpreadsheetHistoryHashTokens.EDIT;
     }
 
     spreadsheetViewportWidgetExecute(viewportWidget, viewportCell, width, height) {

--- a/src/spreadsheet/reference/cell/style/SpreadsheetCellStyleSaveHistoryHashToken.js
+++ b/src/spreadsheet/reference/cell/style/SpreadsheetCellStyleSaveHistoryHashToken.js
@@ -2,6 +2,7 @@ import CharSequences from "../../../../CharSequences.js";
 import Equality from "../../../../Equality.js";
 import Preconditions from "../../../../Preconditions.js";
 import SpreadsheetCellStyleHistoryHashToken from "./SpreadsheetCellStyleHistoryHashToken.js";
+import SpreadsheetHistoryHashTokens from "../../../history/SpreadsheetHistoryHashTokens.js";
 import TextStyle from "../../../../text/TextStyle.js";
 
 /**
@@ -40,6 +41,8 @@ export default class SpreadsheetCellStyleSaveHistoryHashToken extends Spreadshee
         return super.historyHashPath() +
             "/" +
             this.propertyName() +
+            "/" +
+            SpreadsheetHistoryHashTokens.SAVE +
             "/" +
             (null != value ? encodeURIComponent(value) : "");
     }


### PR DESCRIPTION
- eg /cell/A1/style/font-style/edit
- eg /cell/A1/style/font-style/save/ITALICS

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/2036
- cell style save should include SAVE token