### PR TITLE
Unknown spreadsheet & label error handling

### DIFF
--- a/src/spreadsheet/SpreadsheetWidget.js
+++ b/src/spreadsheet/SpreadsheetWidget.js
@@ -27,4 +27,10 @@ export default class SpreadsheetWidget extends React.Component {
             10
         );
     }
+
+    showErrorErrorHandler(showError) {
+        return (statusCode, statusMessage) => {
+            showError(statusMessage);
+        };
+    }
 }

--- a/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
@@ -75,6 +75,44 @@ export default class SpreadsheetHistoryAwareWidget extends SpreadsheetWidget {
         }
     }
 
+    /**
+     * Wraps another error handler but when invoked clears the viewport-selection. This is useful for cases such as
+     * clearing the selection of an invalid or unknown label.
+     */
+    unknownLabelErrorHandler(showError) {
+        const history = this.props.history;
+
+        return (statusCode, statusMessage) => {
+            this.log("statusCode: " + statusCode + " statusMessage: " + statusMessage);
+
+            if(statusCode >= 400){
+                const tokens = SpreadsheetHistoryHash.emptyTokens();
+                tokens[SpreadsheetHistoryHashTokens.VIEWPORT_SELECTION] = null;
+                history.mergeAndPush(tokens);
+
+                showError(statusCode, statusMessage);
+            }
+        }
+    }
+
+    /**
+     * Displays the error, and then restores the original (given) spreadsheetId.
+     */
+    unknownSpreadsheetErrorHandler(spreadsheetId, showError) {
+        const history = this.props.history;
+
+        return (statusCode, statusMessage) => {
+            this.log("statusCode: " + statusCode + " statusMessage: " + statusMessage);
+
+            showError(statusCode, statusMessage);
+
+            const tokens = SpreadsheetHistoryHash.emptyTokens();
+            tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_ID] = spreadsheetId;
+            tokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME] = null;
+            history.mergeAndPush(tokens);
+        };
+    }
+
     showError(message, error) {
         throw new Error("Sub classes must override showError");
     }

--- a/src/spreadsheet/message/SpreadsheetMessenger.js
+++ b/src/spreadsheet/message/SpreadsheetMessenger.js
@@ -113,8 +113,6 @@ export default class SpreadsheetMessenger {
                     const statusCode = resp.status;
                     const statusText = resp.statusText;
                     switch(Math.floor(statusCode / 100)) {
-                        case 1:
-                            throw new Error("1xx " + statusCode + "=" + statusText);
                         case 2:
                             response.statusCode = statusCode;
                             response.statusText = statusText;
@@ -122,14 +120,16 @@ export default class SpreadsheetMessenger {
                             return 204 === statusCode ?
                                 Promise.resolve(null) :
                                 resp.json();
+                        case 1:
                         case 3:
-                            throw new Error("Redirect " + statusCode + "=" + statusText);
                         case 4:
-                            throw new Error("Bad request " + statusCode + "=" + statusText);
                         case 5:
-                            throw new Error("Server error " + statusCode + "=" + statusText);
                         default:
-                            throw new Error("Misc error: " + statusCode + "=" + statusText);
+                            failure(
+                                statusCode,
+                                statusText
+                            );
+                            return Promise.resolve(null);
                     }
                 })
                 .then(json => {
@@ -137,7 +137,10 @@ export default class SpreadsheetMessenger {
                     success(json);
                 })
                 .catch((e) => {
-                    failure("fetch failed, using " + url + " with " + JSON.stringify(parameters) + "\n" + e, e);
+                    failure(
+                        null,
+                        e.message
+                    );
                 }));
     }
 

--- a/src/spreadsheet/meta/SpreadsheetMetadataWidget.js
+++ b/src/spreadsheet/meta/SpreadsheetMetadataWidget.js
@@ -66,7 +66,10 @@ export default class SpreadsheetMetadataWidget extends SpreadsheetHistoryAwareSt
         this.props.spreadsheetMetadataCrud.patch(
             id,
             JSON.stringify(patch),
-            this.props.showError
+            this.unknownSpreadsheetErrorHandler(
+                null,
+                this.showErrorErrorHandler(this.props.showError)
+            )
         );
     }
 }

--- a/src/spreadsheet/meta/drawer/SpreadsheetMetadataDrawerWidget.js
+++ b/src/spreadsheet/meta/drawer/SpreadsheetMetadataDrawerWidget.js
@@ -200,31 +200,33 @@ class SpreadsheetMetadataDrawerWidget extends SpreadsheetMetadataWidget {
     }
 
     onSpreadsheetMetadata(method, id, url, requestMetadata, responseMetadata) {
-        this.setState({
-            createDateTimeFormatted: "", // clear forcing reformatting of create/modified timestamps.
-            modifiedDateTimeFormatted: "",
-            spreadsheetMetadata: responseMetadata,
-        });
+        if(responseMetadata) {
+            this.setState({
+                createDateTimeFormatted: "", // clear forcing reformatting of create/modified timestamps.
+                modifiedDateTimeFormatted: "",
+                spreadsheetMetadata: responseMetadata,
+            });
 
-        this.giveFocus(
-            () => {
-                const {
-                    giveMetadataFocus,
-                    metadata,
-                } = this.state;
+            this.giveFocus(
+                () => {
+                    const {
+                        giveMetadataFocus,
+                        metadata,
+                    } = this.state;
 
-                var element;
-                if(giveMetadataFocus && metadata && !metadata.item()){
-                    this.setState({
-                        giveMetadataFocus: false,
-                    });
+                    var element;
+                    if(giveMetadataFocus && metadata && !metadata.item()){
+                        this.setState({
+                            giveMetadataFocus: false,
+                        });
 
-                    element = this.drawer.current;
+                        element = this.drawer.current;
+                    }
+
+                    return element;
                 }
-
-                return element;
-            }
-        );
+            );
+        }
     }
 
     render() {

--- a/src/spreadsheet/meta/drawer/SpreadsheetMetadataDrawerWidgetValue.js
+++ b/src/spreadsheet/meta/drawer/SpreadsheetMetadataDrawerWidgetValue.js
@@ -244,19 +244,21 @@ export default class SpreadsheetMetadataDrawerWidgetValue extends SpreadsheetHis
      * Updates the value and default value whenever a new SpreadsheetMetadata is loaded.
      */
     onSpreadsheetMetadata(method, id, url, requestMetadata, responseMetadata) {
-        const {getValue} = this.props;
+        if(responseMetadata){
+            const {getValue} = this.props;
 
-        const value = getValue(responseMetadata);
-        const defaultValue = getValue(responseMetadata.getIgnoringDefaults(SpreadsheetMetadata.DEFAULTS));
+            const value = getValue(responseMetadata);
+            const defaultValue = getValue(responseMetadata.getIgnoringDefaults(SpreadsheetMetadata.DEFAULTS));
 
-        this.log(".onSpreadsheetMetadata got value: " + value + " default=" + defaultValue, responseMetadata);
+            this.log(".onSpreadsheetMetadata got value: " + value + " default=" + defaultValue, responseMetadata);
 
-        this.setState({
-            value: value,
-            value2: value,
-            savedValue: value,
-            defaultValue: defaultValue,
-        });
+            this.setState({
+                value: value,
+                value2: value,
+                savedValue: value,
+                defaultValue: defaultValue,
+            });
+        }
     }
 
     prefix() {

--- a/src/spreadsheet/meta/name/SpreadsheetNameWidget.js
+++ b/src/spreadsheet/meta/name/SpreadsheetNameWidget.js
@@ -131,13 +131,15 @@ export default class SpreadsheetNameWidget extends SpreadsheetMetadataWidget {
     }
 
     onSpreadsheetMetadata(method, id, url, requestMetadata, responseMetadata) {
-        const spreadsheetName = responseMetadata ? responseMetadata.getIgnoringDefaults(SpreadsheetMetadata.SPREADSHEET_NAME) : null;
+        if(responseMetadata){
+            const spreadsheetName = responseMetadata.getIgnoringDefaults(SpreadsheetMetadata.SPREADSHEET_NAME);
 
-        this.setState({
-            id: id, // SpreadsheetId
-            name: spreadsheetName,
-            value: spreadsheetName ? spreadsheetName.value() : "",
-        });
+            this.setState({
+                id: id, // SpreadsheetId
+                name: spreadsheetName,
+                value: spreadsheetName ? spreadsheetName.value() : "",
+            });
+        }
     }
 }
 

--- a/src/spreadsheet/reference/cell/SpreadsheetCellWidget.js
+++ b/src/spreadsheet/reference/cell/SpreadsheetCellWidget.js
@@ -82,7 +82,7 @@ export default class SpreadsheetCellWidget extends SpreadsheetHistoryAwareStateW
         props.spreadsheetDeltaCellCrud.patch(
             selection,
             delta,
-            props.showError,
+            this.unknownLabelErrorHandler(props.showError),
         );
     }
 }

--- a/src/spreadsheet/reference/cell/style/SpreadsheetCellStylePropertyWidget.js
+++ b/src/spreadsheet/reference/cell/style/SpreadsheetCellStylePropertyWidget.js
@@ -46,35 +46,37 @@ export default class SpreadsheetCellStylePropertyWidget extends SpreadsheetCellW
      * If the delta includes an updated formula text for the cell being edited update text.
      */
     onSpreadsheetDelta(method, cellOrLabel, url, requestDelta, responseDelta) {
-        const viewportSelectionToken = this.state.viewportSelection;
+        if(responseDelta) {
+            const viewportSelectionToken = this.state.viewportSelection;
 
-        if(viewportSelectionToken instanceof SpreadsheetCellHistoryHashToken){
-            const viewportSelection = viewportSelectionToken.viewportSelection();
-            var selection = viewportSelection.selection();
+            if(viewportSelectionToken instanceof SpreadsheetCellHistoryHashToken){
+                const viewportSelection = viewportSelectionToken.viewportSelection();
+                var selection = viewportSelection.selection();
 
-            if(selection instanceof SpreadsheetLabelName) {
-                selection = responseDelta.cellReference(selection);
+                if(selection instanceof SpreadsheetLabelName) {
+                    selection = responseDelta.cellReference(selection);
+                }
+
+                const propertyName = this.props.propertyName;
+                const propertyValue = this.props.propertyValue;
+                const selected = -1 !== selection.values()
+                    .findIndex(
+                        (cellReference) => {
+                            const cell = responseDelta.cell(cellReference);
+                            return Boolean(
+                                cell && Equality.safeEquals(
+                                    propertyValue,
+                                    cell.style()
+                                        .get(propertyName)
+                                )
+                            );
+                        });
+
+                // selection might be a cell or cell-range
+                this.setState({
+                    selected: selected,
+                });
             }
-
-            const propertyName = this.props.propertyName;
-            const propertyValue = this.props.propertyValue;
-            const selected = -1 !== selection.values()
-                .findIndex(
-                    (cellReference) => {
-                        const cell = responseDelta.cell(cellReference);
-                        return Boolean(
-                            cell && Equality.safeEquals(
-                                propertyValue,
-                                cell.style()
-                                    .get(propertyName)
-                            )
-                        );
-                    });
-
-            // selection might be a cell or cell-range
-            this.setState({
-               selected: selected,
-            });
         }
     }
 

--- a/src/spreadsheet/reference/label/SpreadsheetLabelMappingWidget.js
+++ b/src/spreadsheet/reference/label/SpreadsheetLabelMappingWidget.js
@@ -355,8 +355,9 @@ export default class SpreadsheetLabelMappingWidget extends SpreadsheetHistoryAwa
         }
     }
 
+    // TODO inline.
     onLabelMappingLoadFailure(message, error) {
-        this.props.showError(message, error);
+        this.props.showError(message);
 
         const state = {};
         this.parseLabel("", state);
@@ -364,6 +365,7 @@ export default class SpreadsheetLabelMappingWidget extends SpreadsheetHistoryAwa
         this.setState(state);
     }
 
+    // TODO inline
     onLabelMappingSaveSuccess(mapping) {
         this.props.notificationShow(SpreadsheetNotification.success("Label saved"));
 


### PR DESCRIPTION
- SpreadsheetMessenger errorHandler now takes statusCode & statusMessage.
- SpreadsheetHistoryAwareWidget.unknownLabelErrorHandler & unknownSpreadsheetErrorHandler
- Updated onSpreadsheetDelta & onSpreadsheetMetadata null response guards.
- cell history hash removed if label was not found.
- spreadsheetId removed and a new empty spreadsheet created if spreadsheetId in url not found.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/2055
- select cell with unknown label should clear label and display error

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/2049
- Handle attempts to load unknown spreadsheet id with error dialog etc