### PR TITLE
SpreadsheetHistoryAwareWidget.log params fix

### DIFF
--- a/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryAwareWidget.js
@@ -105,7 +105,8 @@ export default class SpreadsheetHistoryAwareWidget extends SpreadsheetWidget {
     }
 
     log(...params) {
-        console.log(this.prefix() + params[0], params.shift());
+        const first = params.shift();
+        console.log(this.prefix() + first, params);
     }
 }
 


### PR DESCRIPTION
- Previously was logging the first param twice and dropping remaining params.