### PR TITLE
SpreadsheetNameHistoryHashToken.spreadsheetNameWidgetExecute dispatch

### DIFF
--- a/src/spreadsheet/meta/name/SpreadsheetNameEditHistoryHashToken.js
+++ b/src/spreadsheet/meta/name/SpreadsheetNameEditHistoryHashToken.js
@@ -8,8 +8,11 @@ export default class SpreadsheetNameEditHistoryHashToken extends SpreadsheetName
 
     static INSTANCE = new SpreadsheetNameEditHistoryHashToken();
 
-    spreadsheetNameWidgetExecute(spreadsheetNameWidget) {
-        // nop
+    spreadsheetNameWidgetExecute(spreadsheetNameWidget, previous) {
+        if(!previous) {
+            spreadsheetNameWidget.beginEditing();
+        }
+        return null;
     }
 
     historyHashPath() {

--- a/src/spreadsheet/meta/name/SpreadsheetNameSaveHistoryHashToken.js
+++ b/src/spreadsheet/meta/name/SpreadsheetNameSaveHistoryHashToken.js
@@ -3,6 +3,7 @@ import Preconditions from "../../../Preconditions.js";
 import SpreadsheetHistoryHashTokens from "../../history/SpreadsheetHistoryHashTokens.js";
 import SpreadsheetMetadata from "../SpreadsheetMetadata.js";
 import SpreadsheetName from "./SpreadsheetName.js";
+import SpreadsheetNameEditHistoryHashToken from "./SpreadsheetNameEditHistoryHashToken.js";
 import SpreadsheetNameHistoryHashToken from "./SpreadsheetNameHistoryHashToken.js";
 
 /**
@@ -28,6 +29,10 @@ export default class SpreadsheetNameSaveHistoryHashToken extends SpreadsheetName
             SpreadsheetMetadata.SPREADSHEET_NAME,
             this.value()
         );
+
+        const historyTokens = SpreadsheetHistoryHashTokens.emptyTokens();
+        historyTokens[SpreadsheetHistoryHashTokens.SPREADSHEET_NAME_EDIT] = new SpreadsheetNameEditHistoryHashToken();
+        return historyTokens;
     }
 
     historyHashPath() {


### PR DESCRIPTION
- ESC while editing fix (also clears /name history hash token).
- Click/Focus loads spreadsheet metadata to fetch name.