### PR TITLE
viewport context menu delete cell fix

### DIFF
--- a/cypress/e2e/Cell.spec.js
+++ b/cypress/e2e/Cell.spec.js
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 
+import SpreadsheetCellRange from "../../src/spreadsheet/reference/cell/SpreadsheetCellRange.js";
 import SpreadsheetCellReference from "../../src/spreadsheet/reference/cell/SpreadsheetCellReference.js";
 import SpreadsheetSelection from "../../src/spreadsheet/reference/SpreadsheetSelection.js";
 import SpreadsheetTesting from "./SpreadsheetTesting.js";
@@ -944,6 +945,57 @@ describe(
                 .should("have.attr", "aria-disabled", "true")
                 .should("have.attr", "href")
                 .and("match", /#\/.*\/.*\/cell\/A1\/unfreeze$/);
+        });
+
+        // context menu delete..........................................................................................
+
+        it("Context menu delete cell", () => {
+            testing.cellFormulaEnterAndSave(B2, "'Deleted");
+
+            testing.cellClick(B2);
+
+            testing.viewportContextMenuOpen(B2)
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
+                .should("have.text", "Delete cell")
+                .should("have.attr", "href")
+                .and("match", /#\/.*\/.*\/cell\/B2\/delete$/)
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
+                .click();
+
+            testing.hash()
+                .should("match", /^#\/.*\/Untitled$/);
+
+            testing.cellFormattedTextCheck(B2, ""); // verify cell has lost its contents.
+        });
+
+        it("Context menu delete cell-range", () => {
+            testing.cellFormulaEnterAndSave(A1, "'NotDeletedA1");
+            testing.cellFormulaEnterAndSave(B2, "'DeletedB2");
+            testing.cellFormulaEnterAndSave(C3, "'DeletedC3");
+            testing.cellFormulaEnterAndSave(D4, "'NotDeletedD4");
+
+            testing.hashAppendAfterSpreadsheetName("/cell/B2:C3");
+
+            testing.historyWait();
+            testing.historyWait(); // less failures with 2x wait
+
+            testing.viewportContextMenuOpen(B2, SpreadsheetCellRange.parse("B2:C3"))
+                .find("#" + SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
+                .should("have.text", "Delete cells")
+                .should("have.attr", "href")
+                .and("match", /#\/.*\/.*\/cell\/B2:C3\/delete$/)
+
+            testing.getById(SpreadsheetSelection.VIEWPORT_CONTEXT_MENU_DELETE_CELL_ID)
+                .click();
+
+            testing.hash()
+                .should("match", /^#\/.*\/Untitled$/);
+
+            testing.cellFormattedTextCheck("A1", "NotDeletedA1");
+            testing.cellFormattedTextCheck(B2, "");
+            testing.cellFormattedTextCheck(C3, "");
+            testing.cellFormattedTextCheck("D4", "NotDeletedD4");
         });
 
         // Freeze.......................................................................................................

--- a/src/spreadsheet/reference/SpreadsheetSelection.js
+++ b/src/spreadsheet/reference/SpreadsheetSelection.js
@@ -1,5 +1,6 @@
 import CharSequences from "../../CharSequences.js";
 import Character from "../../Character.js";
+import SpreadsheetCellDeleteHistoryHashToken from "./cell/SpreadsheetCellDeleteHistoryHashToken.js";
 import SpreadsheetCellFreezeHistoryHashToken from "./cell/SpreadsheetCellFreezeHistoryHashToken.js";
 import SpreadsheetCellUnFreezeHistoryHashToken from "./cell/SpreadsheetCellUnFreezeHistoryHashToken.js";
 import SpreadsheetColumnOrRowClearHistoryHashToken from "./columnrow/SpreadsheetColumnOrRowClearHistoryHashToken.js";
@@ -174,7 +175,7 @@ export default class SpreadsheetSelection extends SystemObject {
     }
 
     viewportContextMenuCellDelete(historyTokens, menuItems, history) {
-        historyTokens[SpreadsheetHistoryHashTokens.VIEWPORT_SELECTION] = new SpreadsheetColumnOrRowDeleteHistoryHashToken(
+        historyTokens[SpreadsheetHistoryHashTokens.VIEWPORT_SELECTION] = new SpreadsheetCellDeleteHistoryHashToken(
             new SpreadsheetViewportSelection(this)
         );
 

--- a/src/spreadsheet/reference/cell/SpreadsheetCellDeleteHistoryHashToken.js
+++ b/src/spreadsheet/reference/cell/SpreadsheetCellDeleteHistoryHashToken.js
@@ -1,6 +1,5 @@
 import SpreadsheetCellHistoryHashToken from "./SpreadsheetCellHistoryHashToken.js";
 import SpreadsheetHistoryHashTokens from "../../history/SpreadsheetHistoryHashTokens.js";
-import viewportSelectionSelectHistoryHashToken from "../../history/viewportSelectionSelectHistoryHashToken.js";
 
 /**
  * A history hash token that represents a cell or cell-range delete
@@ -25,11 +24,8 @@ export default class SpreadsheetCellDeleteHistoryHashToken extends SpreadsheetCe
             );
         }
 
-        return SpreadsheetHistoryHashTokens.viewportSelection(
-            viewportSelectionSelectHistoryHashToken(
-                viewportSelection
-            )
-        );
+        // clear selection
+        return SpreadsheetHistoryHashTokens.viewportSelection(null);
     }
 
     labelMappingWidget(widget) {


### PR DESCRIPTION
- Previously selecting a cell or cell-range and clicking "delete cell/s" would do nothing, because the onClick handler was pushing an invalid viewport-selection history hash token.
- After clicking delete the selection is cleared (removed).

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/1881
- cell context menu "Delete Cell" & "Delete cells" do nothing