### PR TITLE
SpreadsheetNameSaveHistoryHashToken should include "save" in history …

### DIFF
--- a/src/spreadsheet/history/SpreadsheetHistoryHash.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.js
@@ -131,14 +131,26 @@ export default class SpreadsheetHistoryHash extends SpreadsheetHistoryHashTokens
                             spreadsheetNameEdit = SpreadsheetNameEditHistoryHashToken.INSTANCE;
                             token = tokens.shift();
 
-                            if(token){
-                                // /$id/$name/name/$new-spreadsheet-name
-                                spreadsheetNameEdit = new SpreadsheetNameSaveHistoryHashToken(
-                                    new SpreadsheetName(
-                                        decodeURIComponent(token)
-                                    )
-                                );
-                                token = tokens.shift();
+                            if(null != token){
+                                switch(token) {
+                                    case SpreadsheetHistoryHashTokens.SAVE:
+                                        const saveName = tokens.shift();
+                                        if(!saveName) {
+                                            errors("Missing spreadsheet name");
+                                            break Loop;
+                                        }
+
+                                        // /$id/$name/name/$new-spreadsheet-name
+                                        spreadsheetNameEdit = new SpreadsheetNameSaveHistoryHashToken(
+                                            new SpreadsheetName(
+                                                decodeURIComponent(saveName)
+                                            )
+                                        );
+                                        token = tokens.shift();
+                                        break;
+                                    default:
+                                        break;
+                                }
                             }
                         }
 

--- a/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
+++ b/src/spreadsheet/history/SpreadsheetHistoryHash.test.js
@@ -558,7 +558,7 @@ testParseAndStringify(
 );
 
 testParseAndStringify(
-    "/spreadsheet-id-123/spreadsheet-name-456/name/new-spreadsheet-name-789",
+    "/spreadsheet-id-123/spreadsheet-name-456/name/save/new-spreadsheet-name-789",
     {
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
@@ -572,7 +572,7 @@ testParseAndStringify(
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
     },
-    "Invalid token: \"A1\"",
+    "Invalid token: \"cell\"",
 );
 
 testParseAndStringify(
@@ -922,7 +922,7 @@ testParseAndStringify(
         "spreadsheet-id": "spreadsheet-id-123",
         "spreadsheet-name": SPREADSHEET_NAME,
     },
-    "Invalid token: \"Label123\""
+    "Invalid token: \"label\""
 );
 
 testParseAndStringify(
@@ -2330,7 +2330,7 @@ testMerge(
     {
         "spreadsheet-name-edit": NAME_SAVE,
     },
-    "/123abc/Untitled4567890/name/new-spreadsheet-name-789"
+    "/123abc/Untitled4567890/name/save/new-spreadsheet-name-789"
 );
 
 testMerge(
@@ -2370,11 +2370,11 @@ testMerge(
     {
         "spreadsheet-name-edit": NAME_SAVE,
     },
-    "/123abc/Untitled456/name/new-spreadsheet-name-789"
+    "/123abc/Untitled456/name/save/new-spreadsheet-name-789"
 );
 
 testMerge(
-    "/123abc/Untitled4567890a/name/new-spreadsheet-name-789",
+    "/123abc/Untitled4567890a/name/save/new-spreadsheet-name-789",
     {
         "spreadsheet-name-edit": null,
     },

--- a/src/spreadsheet/meta/name/SpreadsheetNameSaveHistoryHashToken.js
+++ b/src/spreadsheet/meta/name/SpreadsheetNameSaveHistoryHashToken.js
@@ -36,7 +36,12 @@ export default class SpreadsheetNameSaveHistoryHashToken extends SpreadsheetName
     }
 
     historyHashPath() {
-        return "/" + SpreadsheetHistoryHashTokens.SPREADSHEET_NAME_PATH + "/" + encodeURIComponent(this.value().value());
+        return "/" +
+            SpreadsheetHistoryHashTokens.SPREADSHEET_NAME_PATH +
+            "/" +
+            SpreadsheetHistoryHashTokens.SAVE +
+            "/" +
+            encodeURIComponent(this.value().value());
     }
 
     equals(other) {


### PR DESCRIPTION
…hash path

- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/2112
- SpreadsheetNameSaveHistoryHashToken should include "save" path component before encoded save name value