### PR TITLE
Preconditions.requireInstance prototype String support

### DIFF
--- a/src/Preconditions.js
+++ b/src/Preconditions.js
@@ -130,13 +130,20 @@ export default class Preconditions {
     }
 
     /**
-     * Throws an exception if value is null or not the correct type
+     * Throws an exception if value is null or not the correct type. Note that prototype may also be the prototype or
+     * constructor.name as a String.
      */
     static requireInstance(value, prototype, label) {
         Preconditions.requireNonNull(value, label);
 
-        if(!(value instanceof prototype)){
-            reportError("Expected " + prototype.name + " "  + label + " got " + value);
+        if(typeof prototype === "string"){
+            if(value.constructor.name !== prototype){
+                reportError("Expected " + prototype + " " + label + " got " + value);
+            }
+        }else {
+            if(!(value instanceof prototype)){
+                reportError("Expected " + prototype.name + " " + label + " got " + value);
+            }
         }
 
         return value;

--- a/src/spreadsheet/reference/SpreadsheetSelectionHistoryHashToken.js
+++ b/src/spreadsheet/reference/SpreadsheetSelectionHistoryHashToken.js
@@ -10,16 +10,11 @@ export default class SpreadsheetSelectionHistoryHashToken extends SpreadsheetHis
     constructor(viewportSelection) {
         super();
 
-        this.viewportSelectionValue = Preconditions.requireObject(
+        this.viewportSelectionValue = Preconditions.requireInstance(
             viewportSelection,
+            "SpreadsheetViewportSelection",
             "viewportSelection"
         );
-
-        // Must check Constructor.name rather than Class to avoid cycles.
-        const viewportSelectionType = viewportSelection.constructor.name;
-        if("SpreadsheetViewportSelection" !== viewportSelectionType){
-            throw new Error("Expected SpreadsheetViewportSelection but got " + viewportSelectionType);
-        }
     }
 
     spreadsheetViewportWidgetExecute(viewportWidget, previousViewportSelection, viewportCell, width, height) {


### PR DESCRIPTION
- In some cases it is not possible to pass the actual prototype, this adds support for passing the prototype name. In both cases checks are still performed and Errors will be thrown for failures.